### PR TITLE
Fix/self consistency and mechanical fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,22 @@
 .idea/
 .vscode/
 
-# Go build output (assets/ boilerplates are reference templates, not built here)
+# Go build output. assets/ templates ARE built in place — assets/README.md makes
+# `go build ./...` a mandatory gate — so their binaries land in the work tree.
 *.test
 *.out
+
+# Compiled binaries from the assets/ templates and the bundled script.
+/skills/go-ultimate/assets/cli-simple/my-tool
+/skills/go-ultimate/assets/cli-cobra/my-cli
+/skills/go-ultimate/assets/webservice/webservice
+/skills/go-ultimate/assets/mcp-server/mcp-server
+/skills/go-ultimate/assets/game/game
+/skills/go-ultimate/scripts/goversion/goversion
+
+# Cross-platform and debugger artifacts
+*.exe
+*.dll
+*.so
+*.dylib
+__debug_bin*

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ The skill lives under [`skills/go-ultimate/`](skills/go-ultimate/) and is struct
 |---|---|
 | `skills/go-ultimate/SKILL.md` | The skill itself — when it applies, the non-negotiable principles, the project-type decision tree, conflict precedence. |
 | `skills/go-ultimate/references/` | Deep dives loaded on demand: `architecture.md`, `engineering-policy.md`, `modern-go.md`, `testing.md`, `code-review.md`, `libraries.md`, `project-layouts.md`, `wiring-and-runtime.md`, `modular-monolith.md`, `mcp-server.md`, `agents.md`. |
-| `skills/go-ultimate/assets/` | Scaffolded project templates per type: `cli-simple`, `cli-cobra`, `library`, `game`, `mcp-server`, `webservice` (all build green with Go 1.26.x). |
+| `skills/go-ultimate/assets/` | Scaffolded project templates per type: `cli-simple`, `cli-cobra`, `library`, `game`, `mcp-server`, `webservice` (all `build`, `vet` and `test -race` green). |
 | `skills/go-ultimate/scripts/` | `goversion/main.go` (detects the project's `go.mod` version) and `check-source-versions.sh` + `source-versions.json` (drift checker for upstream donor sources). |
 | `skills/go-ultimate/evals/` | Example prompts and expected behaviors for catching skill drift. |
 
@@ -54,7 +54,7 @@ The skill synthesizes nine upstream sources. Full attribution and the live pins 
 
 **General Go:** `teetsh-org/claude-skills#golang-code-review`, `JetBrains/go-modern-guidelines#use-modern-go`, `powerman/skills#go-bounded-context-hexagonal` (v0.6.0), `powerman/skills#go-engineering-policy` (v0.0.5).
 
-**Agent / MCP:** `cloudwego/eino` (orchestration design + ADK), `modelcontextprotocol/go-sdk` (v1.6.1), `philschmid.de#mcp-best-practices`, `modelcontextprotocol.info#docs/best-practices`.
+**Agent / MCP:** `cloudwego/eino#orchestration-design-principles`, `cloudwego/eino#adk-0.1`, `modelcontextprotocol/go-sdk` (v1.6.1), `philschmid.de#mcp-best-practices`, `modelcontextprotocol.info#docs/best-practices`.
 
 > Originally also sourced from `danicat/skills#go-best-practices` and `danicat/skills#go-project-setup`; both were deleted upstream on 2026-07-21. Their distilled content is now owned and maintained by this skill (project-setup boilerplates under `assets/`, best-practices material folded into `references/engineering-policy.md` and `references/code-review.md`).
 

--- a/skills/go-ultimate/assets/README.md
+++ b/skills/go-ultimate/assets/README.md
@@ -41,7 +41,10 @@ is a minimal, runnable skeleton matching the layout the skill mandates.
 - `package main` is **thin**: signal handling + `os.Exit` only. All testable logic
   lives in a `run(ctx, ...) error` function. (See
   [engineering-policy.md § `package main`](../references/engineering-policy.md).)
-- Graceful shutdown via `signal.NotifyContext` for `os.Interrupt`/`SIGTERM`.
+- Graceful shutdown via `signal.NotifyContext` for `os.Interrupt`/`SIGTERM` in every
+  template that owns its own run loop (`cli-simple`, `cli-cobra`, `webservice`,
+  `mcp-server`). `game/` is the exception: Ebitengine owns the loop and exits via
+  `Update() error`.
 - No `pkg/` directory. Private code under `internal/`; multiple binaries under `cmd/`.
 - Layouts follow [project-layouts.md](../references/project-layouts.md).
 

--- a/skills/go-ultimate/assets/cli-cobra/cmd/root.go
+++ b/skills/go-ultimate/assets/cli-cobra/cmd/root.go
@@ -11,13 +11,22 @@ package cmd
 import (
 	"context"
 	"fmt"
+	"os"
+	"os/signal"
+	"syscall"
 
 	"github.com/spf13/cobra"
 )
 
 // Execute runs the root command. It is the only entry point main calls.
+//
+// The command tree runs on a context cancelled by SIGINT/SIGTERM, so every
+// RunE can honour cancellation via cmd.Context().
 func Execute() error {
-	return newRootCmd().ExecuteContext(context.Background())
+	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	defer stop()
+
+	return newRootCmd().ExecuteContext(ctx)
 }
 
 // newRootCmd builds and returns the root command. Add subcommands by calling

--- a/skills/go-ultimate/assets/cli-simple/main.go
+++ b/skills/go-ultimate/assets/cli-simple/main.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	"flag"
 	"fmt"
+	"io"
 	"os"
 	"os/signal"
 	"syscall"
@@ -30,7 +31,7 @@ func main() {
 // run holds all testable logic. It takes ctx (for cancellation), the parsed
 // inputs, and an io.Writer (so tests can capture output without os.Stdout).
 // No flag parsing, no os.Exit — main owns those.
-func run(ctx context.Context, name string, stdout *os.File) error {
+func run(ctx context.Context, name string, stdout io.Writer) error {
 	select {
 	case <-ctx.Done():
 		return ctx.Err()

--- a/skills/go-ultimate/assets/library/library_test.go
+++ b/skills/go-ultimate/assets/library/library_test.go
@@ -21,7 +21,7 @@ func TestHello(t *testing.T) {
 		{name: "empty", in: "", want: "Hello, !"},
 	}
 	for _, tc := range cases {
-		tc := tc
+		// No `tc := tc` — since Go 1.22 each iteration gets its own copy.
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 			if got := library.Hello(tc.in); got != tc.want {

--- a/skills/go-ultimate/assets/mcp-server/main.go
+++ b/skills/go-ultimate/assets/mcp-server/main.go
@@ -5,29 +5,48 @@
 // into cmd/ + internal/ when handlers multiply. See go-ultimate/references/mcp-server.md
 // for SDK choice, typed-handler design, two-channel errors, and tool-design discipline.
 //
-// main() is thin: it builds the server, registers tools, and runs. Real servers
-// move tool handlers into internal/ and keep main for wiring.
+// main() is thin — signals and exit code only; run(ctx) builds the server,
+// registers tools, and serves. Real servers move tool handlers into internal/
+// and keep run for wiring.
 package main
 
 import (
 	"context"
-	"log"
+	"errors"
+	"fmt"
+	"os"
+	"os/signal"
+	"syscall"
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 )
 
+// greetArgs is the typed argument struct for the "greet" tool. Avoid
+// map[string]any in tool args: it raises hallucination and mis-selection.
+// See references/mcp-server.md.
+type greetArgs struct {
+	Name string `json:"name" jsonschema:"the person to greet"`
+}
+
 func main() {
+	// Ctrl-C / SIGTERM cancels the context the server runs on. main owns signals.
+	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	defer stop()
+
+	if err := run(ctx); err != nil {
+		fmt.Fprintf(os.Stderr, "mcp-server: %v\n", err)
+		os.Exit(1)
+	}
+}
+
+func run(ctx context.Context) error {
 	server := mcp.NewServer(&mcp.Implementation{
 		Name:    "greeter",
 		Version: "0.1.0",
 	}, nil)
 
 	// Typed tool via generic mcp.AddTool — InputSchema is inferred from the args
-	// type (json + jsonschema struct tags). Avoid map[string]any in tool args:
-	// it raises hallucination and mis-selection. See references/mcp-server.md.
-	type greetArgs struct {
-		Name string `json:"name" jsonschema:"the person to greet"`
-	}
+	// type (json + jsonschema struct tags).
 	mcp.AddTool(server, &mcp.Tool{
 		Name:        "greet",
 		Description: "say hi to a person",
@@ -42,8 +61,10 @@ func main() {
 		}, nil, nil
 	})
 
-	// Run the server on stdin/stdout. Ctrl-C cancels via context.
-	if err := server.Run(context.Background(), &mcp.StdioTransport{}); err != nil {
-		log.Printf("mcp-server failed: %v", err)
+	// Run the server on stdin/stdout until the client disconnects or ctx is
+	// cancelled. A cancelled context is a normal shutdown, not a failure.
+	if err := server.Run(ctx, &mcp.StdioTransport{}); err != nil && !errors.Is(err, context.Canceled) {
+		return fmt.Errorf("run stdio server: %w", err)
 	}
+	return nil
 }

--- a/skills/go-ultimate/assets/webservice/internal/app/app.go
+++ b/skills/go-ultimate/assets/webservice/internal/app/app.go
@@ -12,11 +12,15 @@ import (
 )
 
 // New constructs the App. Real wiring goes in wire.go (parent dir).
-func New() port.App {
+//
+// It returns *App, not port.App: "accept interfaces, return structs" (SKILL.md
+// principle 7). Callers store it in a port.App field — see wire.go.
+func New() *App {
 	return &App{}
 }
 
-// App implements port.App. Keep the struct unexported; expose only the interface.
+// App implements port.App. Callers depend on the port.App interface, never on
+// this type directly.
 type App struct {
 	// Owned resources (DB pool, clients) would live here as private fields.
 }

--- a/skills/go-ultimate/assets/webservice/internal/in/http/handler.go
+++ b/skills/go-ultimate/assets/webservice/internal/in/http/handler.go
@@ -6,7 +6,6 @@
 package inhttp
 
 import (
-	"context"
 	"encoding/json"
 	"log/slog"
 	"net/http"
@@ -50,7 +49,3 @@ func logging(next http.Handler) http.Handler {
 		next.ServeHTTP(w, r)
 	})
 }
-
-// _ ensures context is imported even when no handler yet uses r.Context()
-// directly (template scaffolding only — remove once handlers consume ctx).
-var _ = context.Background

--- a/skills/go-ultimate/assets/webservice/main.go
+++ b/skills/go-ultimate/assets/webservice/main.go
@@ -21,29 +21,34 @@ import (
 	"syscall"
 	"time"
 
+	inhttp "example.com/webservice/internal/in/http"
 	"example.com/webservice/internal/port"
-	"example.com/webservice/internal/in/http"
 )
 
 func main() {
-	if err := run(); err != nil {
+	// Long-lived base context, cancelled by SIGINT/SIGTERM. main owns signals.
+	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	defer stop()
+
+	if err := run(ctx); err != nil {
 		fmt.Fprintf(os.Stderr, "webservice: %v\n", err)
 		os.Exit(1)
 	}
 }
 
-func run() error {
-	// Long-lived base context, cancelled by SIGINT/SIGTERM.
-	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
-	defer stop()
-
-	// In a real service cfg would come from flags/env and be Resolve()d here.
-	app := port.App(nil) // wire builds the real app; this is a template
+// run holds everything testable. A real service takes a resolved business Config
+// as its second parameter — run(ctx, cfg) error — and passes it to Wire.
+func run(ctx context.Context) error {
+	var app port.App // nil here: Wire builds the real one. See wire.go.
 	rt, err := Wire(ctx, app)
 	if err != nil {
 		return fmt.Errorf("wire: %w", err)
 	}
-	defer rt.Close()
+	defer func() {
+		if err := rt.Close(); err != nil {
+			slog.Error("releasing runtime resources", "err", err)
+		}
+	}()
 
 	addr := net.JoinHostPort("localhost", "8080")
 	httpServer := &http.Server{

--- a/skills/go-ultimate/evals/README.md
+++ b/skills/go-ultimate/evals/README.md
@@ -27,7 +27,9 @@ These are lightweight smoke tests, not a full eval harness — see
 - Agent runs the bundled detector:
   `go run <skill-dir>/scripts/goversion/main.go .`
 - Agent states the detected version once, e.g. *"This project is using Go 1.24, so I'll use features up to and including this version."*
-- For Go 1.22+, the answer uses `cmp.Or(s, "unknown")` (not an `if`/`else` chain).
+- For Go 1.22+, the answer uses `cmp.Or(list...)` with `"unknown"` as the final fallback
+  (`cmp.Or(append(list, "unknown")...)`, or `cmp.Or(cmp.Or(list...), "unknown")`) — not an
+  `if`/`else` chain.
 - For Go < 1.22, the answer falls back to an `if`/`else` (the skill does not use features newer than the target).
 
 **Failure signals:**
@@ -142,7 +144,7 @@ func NewServer(opts ...Option) *Server { ... }
 **Expected behavior:**
 - Skill activates (MCP server + Go).
 - Agent uses the **official `modelcontextprotocol/go-sdk`** (not `mark3labs/mcp-go`) as the default, with a one-line rationale if asked.
-- Agent uses **typed tool handlers via `mcp.AddTool[In, Out]`** (generics) — not `map[string]any` args.
+- Agent uses **typed tool handlers via the generic `mcp.AddTool`** (`In`/`Out` inferred from the handler) — not `map[string]any` args.
 - Agent implements **two-channel errors**: tool-execution failure as `*mcp.CallToolResult{IsError: true}`, protocol failure as a Go `error`.
 - Agent designs the tool around the **outcome** ("search and return top result with snippet"), not a CRUD operation.
 - Tool args are a **flat typed struct** with constrained types.

--- a/skills/go-ultimate/references/engineering-policy.md
+++ b/skills/go-ultimate/references/engineering-policy.md
@@ -219,7 +219,7 @@ mix. Do not introduce a `Ctx` alias in a project that does not already use one.
 ```go
 g, ctx := errgroup.WithContext(ctx)
 for _, item := range items {
-    item := item
+    // No `item := item` — since Go 1.22 each iteration gets its own copy.
     g.Go(func() error { return process(ctx, item) })
 }
 if err := g.Wait(); err != nil { ... }

--- a/skills/go-ultimate/references/mcp-server.md
+++ b/skills/go-ultimate/references/mcp-server.md
@@ -91,10 +91,24 @@ idiomatic, composable place for them.
 Tool handlers are **typed via generics**:
 
 ```go
-mcp.AddTool[In, Out](server, &mcp.Tool{...}, handler)
-// handler: func(context.Context, *mcp.ServerRequest[*mcp.CallToolParamsFor[In]])
-//                       (*mcp.CallToolResultFor[Out], error)
+// mcp/server.go
+func AddTool[In, Out any](s *Server, t *Tool, h ToolHandlerFor[In, Out])
+
+// mcp/tool.go — the handler shape
+type ToolHandlerFor[In, Out any] func(
+    context.Context, *CallToolRequest, In,
+) (*CallToolResult, Out, error)
 ```
+
+`In` and `Out` are inferred from the handler, so call sites read
+`mcp.AddTool(server, &mcp.Tool{...}, handler)` without explicit type arguments —
+see [`assets/mcp-server/main.go`](../assets/mcp-server/main.go).
+
+> **Do not copy the handler signature out of the SDK's `design/design.md`.** That
+> document still shows the pre-1.0 shape
+> (`func(ctx, *ServerRequest[*CallToolParamsFor[In]]) (*CallToolResultFor[Out], error)`);
+> those types do not exist in the released `mcp` package. The signature above is
+> the one in v1.6.1.
 
 - `mcp.AddTool[In,Out]` **infers `InputSchema` from `In`** (if nil) and
   `OutputSchema` from `Out` (if nil, unless `Out` is `any`); it will not modify

--- a/skills/go-ultimate/references/modern-go.md
+++ b/skills/go-ultimate/references/modern-go.md
@@ -25,10 +25,15 @@ State the version once: *"This project is using Go X.XX, so I'll use features up
 to and including this version."* Then proceed — do not list features or ask for
 confirmation on each one.
 
-> Why run from the skill directory rather than the target project? `go run
-> <abs-path>` from inside another module fails with "directory … outside main
-> module". The detector is a stdlib-only single file, so you can also copy the
-> `main.go` into the target project and run it there if you prefer.
+> Pass the **file** path, not the directory. `go run <skill-dir>/scripts/goversion/main.go`
+> works from inside any module; `go run <skill-dir>/scripts/goversion` (the package
+> form) fails with "directory … outside main module or its selected dependencies".
+>
+> `go run` still compiles in the *target* module's build context, so a broken
+> `go.mod`, an unavailable `toolchain` directive, or `-mod=vendor` can make the
+> detector fail to start. The detector is a stdlib-only single file, so in that
+> case copy the `main.go` into a scratch directory and run it there, or read the
+> `go` directive out of `go.mod` directly.
 
 ## Contents
 

--- a/skills/go-ultimate/references/project-layouts.md
+++ b/skills/go-ultimate/references/project-layouts.md
@@ -102,18 +102,41 @@ cli-simple/
 └── *.go                        Other commands / helpers in package main.
 ```
 
-### Multi-command CLI: `cmd/` + flat internal
+### Multi-command CLI (one binary, several subcommands): `cmd/` + `internal/`
+
+One binary at the root; `cmd/` is a **package of subcommand constructors**, not a
+directory of binaries. Matches [`../assets/cli-cobra/`](../assets/cli-cobra/).
 
 ```text
 cli-multi/
 ├── go.mod
+├── main.go                     Thin: calls cmd.Execute().
 ├── cmd/
-│   ├── root/main.go            cmd root - dispatches to subcommands.
-│   ├── add/main.go
-│   └── remove/main.go
+│   ├── root.go                 newRootCmd(); owns global flags, adds subcommands.
+│   ├── add.go                  newAddCmd()
+│   └── remove.go               newRemoveCmd()
 └── internal/
     ├── config/config.go
     └── store/store.go
+```
+
+Build commands with factory functions (`newRootCmd`, `newAddCmd`, …) rather than
+package-level vars, so no hidden global state leaks between tests or invocations.
+
+### Multiple binaries: `cmd/<app-name>/main.go`
+
+Only when the repo genuinely ships more than one executable — a different rule
+from the one above, and the one [engineering-policy.md](engineering-policy.md)
+§ `package main` refers to.
+
+```text
+tools/
+├── go.mod
+├── cmd/
+│   ├── importer/main.go        Binary 1.
+│   └── reporter/main.go        Binary 2.
+└── internal/
+    └── store/store.go          Shared private code.
 ```
 
 ### The `run(ctx, cfg) error` pattern (mandatory)
@@ -124,6 +147,7 @@ package main
 
 import (
     "context"
+    "fmt"
     "os"
     "os/signal"
     "syscall"
@@ -135,6 +159,7 @@ func main() {
 
     cfg := parseFlags()
     if err := run(ctx, cfg); err != nil {
+        fmt.Fprintf(os.Stderr, "my-tool: %v\n", err)
         os.Exit(1)
     }
 }

--- a/skills/go-ultimate/references/testing.md
+++ b/skills/go-ultimate/references/testing.md
@@ -58,7 +58,6 @@ func TestDoThing(t *testing.T) {
         {name: "too big", input: "!!!", wantErr: app.ErrTooBig},
     }
     for _, tt := range tests {
-        tt := tt
         t.Run(tt.name, func(t *testing.T) {
             t.Parallel()
             err := app.DoThing(tt.input)
@@ -81,7 +80,7 @@ func TestDoThing(t *testing.T) {
 - **`go.uber.org/mock/mockgen` (gomock)** by default — for interaction-based
   tests where assertions are about exact calls, arguments, call counts,
   matchers, or ordering.
-- **`github.com/unknwon/go-mockgen`** for stateful fakes — when tests read better
+- **`github.com/derision-test/go-mockgen`** for stateful fakes — when tests read better
   as world-state transitions than as long `EXPECT()` chains, especially when a
   dependency needs default behavior plus queued per-call overrides and optional
   post-hoc inspection of call history. List interface names explicitly with

--- a/skills/go-ultimate/scripts/check-source-versions.sh
+++ b/skills/go-ultimate/scripts/check-source-versions.sh
@@ -40,8 +40,11 @@ fi
 github_path_sha() {
     local repo="$1" path="$2"
     local sha
+    # `// empty` matters: on an empty array (path deleted, repo renamed, file
+    # moved) jq would otherwise print the string "null", which passes the -z
+    # test below and gets reported as DRIFT instead of FETCH ERROR.
     sha=$(gh api "repos/${repo}/commits?path=${path}&per_page=1" \
-            --jq '.[0].sha' 2>/dev/null || true)
+            --jq '.[0].sha // empty' 2>/dev/null || true)
     if [[ -z "$sha" ]]; then
         echo "FETCH_ERROR"
     else
@@ -54,10 +57,10 @@ github_path_sha() {
 github_latest_tag() {
     local repo="$1" tag
     # Prefer latest published release.
-    tag=$(gh api "repos/${repo}/releases/latest" --jq '.tag_name' 2>/dev/null || true)
+    tag=$(gh api "repos/${repo}/releases/latest" --jq '.tag_name // empty' 2>/dev/null || true)
     if [[ -z "$tag" ]]; then
         # Fall back to most recently pushed tag.
-        tag=$(gh api "repos/${repo}/tags?per_page=1" --jq '.[0].name' 2>/dev/null || true)
+        tag=$(gh api "repos/${repo}/tags?per_page=1" --jq '.[0].name // empty' 2>/dev/null || true)
     fi
     if [[ -z "$tag" ]]; then
         echo "FETCH_ERROR"

--- a/skills/go-ultimate/scripts/goversion/main.go
+++ b/skills/go-ultimate/scripts/goversion/main.go
@@ -1,16 +1,25 @@
 package main
 
 // goversion extracts the `go` directive from a project's go.mod and prints it.
-// This is a one-purpose tool: its output format is EXACTLY the same as the inline
-// shell command from the original JetBrains use-modern-go SKILL.md:
+//
+// It replaces the inline shell command from the original JetBrains use-modern-go
+// SKILL.md:
 //
 //	grep -rh "^go " --include="go.mod" . 2>/dev/null | cut -d' ' -f2 \
 //	  | sort | uniq -c | sort -nr | head -1 | xargs | cut -d' ' -f2 \
 //	  | grep . || echo unknown
 //
-// The output is the raw version string (e.g. "1.24.3") followed by a newline.
-// When no go.mod or no go directive is found, it prints the current Go runtime
-// version instead of "unknown".
+// Two deliberate differences from that one-liner:
+//
+//   - It reads exactly one go.mod — the one in the directory it is given. It does
+//     not recurse, so a monorepo with several modules must be pointed at the
+//     module of interest rather than at its root.
+//   - When no go.mod or no go directive is found it prints the current Go runtime
+//     version instead of "unknown", and explains the fallback on stderr. stdout
+//     therefore always carries a usable version.
+//
+// The output on stdout is the raw version string (e.g. "1.24.3") followed by a
+// newline.
 //
 // Usage:
 //
@@ -23,6 +32,7 @@ package main
 import (
 	"bufio"
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -36,37 +46,31 @@ func main() {
 	if len(os.Args) > 1 {
 		dir = os.Args[1]
 	}
-	if err := run(context.Background(), os.Stdout, dir); err != nil {
+	if err := run(context.Background(), os.Stdout, os.Stderr, dir); err != nil {
+		fmt.Fprintf(os.Stderr, "goversion: %v\n", err)
 		os.Exit(1)
 	}
 }
 
-// --- public API used by tests (external package) ---
-
-// ParseGoDirectiveForTest exposes parseGoDirective to the external test package.
-func ParseGoDirectiveForTest(data string) (string, error) { return parseGoDirective(data) }
-
-// RunForTest exposes run to the external test package.
-func RunForTest(ctx context.Context, w io.Writer, dir string) error { return run(ctx, w, dir) }
-
-// ErrNoGoModForTest exposes errNoGoMod to the external test package.
-var ErrNoGoModForTest = errNoGoMod
-
-// ErrNoGoDirectiveForTest exposes errNoGoDirective to the external test package.
-var ErrNoGoDirectiveForTest = errNoGoDirective
-
 // --- internal logic ---
 
 // run reads go.mod under dir, parses the `go` directive, and writes the version
-// string to w. On any failure (no go.mod, no directive, read error, parse error),
-// it falls back to the Go runtime version — mirroring the original script's
-// "|| echo unknown" but with the real version.
-func run(ctx context.Context, w io.Writer, dir string) error {
+// string to stdout. On any failure (no go.mod, no directive, read error, parse
+// error) it falls back to the Go runtime version and reports why on stderr —
+// mirroring the original script's "|| echo unknown" but with the real version.
+// It returns an error only when the version cannot be written.
+func run(ctx context.Context, stdout, stderr io.Writer, dir string) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
 	ver, err := detectVersion(dir)
 	if err != nil {
+		fmt.Fprintf(stderr, "goversion: %v; falling back to the Go runtime version\n", err)
 		ver = runtimeVersion()
 	}
-	fmt.Fprintln(w, ver)
+	if _, err := fmt.Fprintln(stdout, ver); err != nil {
+		return fmt.Errorf("write version: %w", err)
+	}
 	return nil
 }
 
@@ -93,8 +97,9 @@ func runtimeVersion() string {
 	return v
 }
 
-// findGoMod resolves go.mod in or below dir. It only checks the one directory;
-// it does not walk upward. Returns an error if go.mod is missing or inaccessible.
+// findGoMod resolves go.mod in dir. It checks that one directory only: it neither
+// walks upward nor descends into subdirectories. Returns an error if go.mod is
+// missing or inaccessible.
 func findGoMod(dir string) (string, error) {
 	abs, err := filepath.Abs(dir)
 	if err != nil {
@@ -127,6 +132,12 @@ func parseGoDirective(data string) (string, error) {
 	for scanner.Scan() {
 		line := strings.TrimSpace(scanner.Text())
 
+		// Skip blank lines and comments FIRST — otherwise a comment ending in "("
+		// is mistaken for a block opener and swallows every line up to the next ")".
+		if line == "" || strings.HasPrefix(line, "//") || strings.HasPrefix(line, "/*") {
+			continue
+		}
+
 		// Track block nesting for multi-line directives.
 		// Block openers look like "require (" or "exclude (" or just "(".
 		// Block closers are ")".
@@ -136,15 +147,12 @@ func parseGoDirective(data string) (string, error) {
 			continue
 		}
 		if line == ")" {
-			inBlock--
+			if inBlock > 0 {
+				inBlock--
+			}
 			continue
 		}
 		if inBlock > 0 || strings.HasPrefix(line, "(") {
-			continue
-		}
-
-		// Skip blank lines and comments.
-		if line == "" || strings.HasPrefix(line, "//") || strings.HasPrefix(line, "/*") {
 			continue
 		}
 
@@ -184,20 +192,6 @@ func isVersion(s string) bool {
 
 // --- errors (private sentinels) ---
 
-var errNoGoMod = errorsNew("no go.mod found")
+var errNoGoMod = errors.New("no go.mod found")
 
-var errNoGoDirective = errorsNew("go.mod has no go directive")
-
-// errorsNew creates a simple sentinel error without importing the errors package.
-func errorsNew(msg string) error { return &simpleError{msg: msg} }
-
-type simpleError struct{ msg string }
-
-func (e *simpleError) Error() string { return e.msg }
-
-func (e *simpleError) Is(target error) bool {
-	if t, ok := target.(*simpleError); ok {
-		return e.msg == t.msg
-	}
-	return e.Error() == target.Error()
-}
+var errNoGoDirective = errors.New("go.mod has no go directive")


### PR DESCRIPTION
# Fix self-contradictions in the skill, its templates and its scripts

Follow-up to the review issues. This PR covers everything that needed no maintainer decision; the design questions are left open and listed at the bottom.

Fixes #2, #3, #7, #9.
Partially addresses #6, #8, #11.

## What changed

**Scripts**

- `goversion`: `parseGoDirective` skipped comments *after* block tracking, so a comment line ending in `(` was read as a block opener and swallowed everything up to the next `)`. A `go.mod` with `// bumped for iter.Seq (` above `go 1.24.3` reported the Go **runtime** version instead of `1.24.3`. Verified against the old and new parser on the same input.
- `goversion`: replaced the hand-rolled `errorsNew`/`simpleError` with `errors.New` — the custom `Is()` compared error *text*, making any two same-message errors `errors.Is`-equivalent. Removed the four exported `*ForTest` shims (no test file exists in the repo). `run()` now honours `ctx`, explains its fallback on stderr, and can actually fail; its doc comment no longer claims parity with a recursive `grep` one-liner it never had.
- `check-source-versions.sh`: `jq` prints the string `"null"` for an empty array, which passed the `[[ -z ]]` guard — a deleted path or renamed repo was reported as **DRIFT** (exit 1) instead of **FETCH ERROR** (exit 2). Added `// empty`. This is the case that already happened twice with the `danicat/*` donors.

**Templates** — each of these was the skill contradicting itself:

| Template | Was | Rule it broke |
|---|---|---|
| `webservice/internal/app` | `New() port.App` | principle 7, `libraries.md` |
| `cli-simple` | `run(…, stdout *os.File)` under a comment promising `io.Writer` | principle 7; defeats the reason for extracting `run()` |
| `webservice/internal/in/http` | `var _ = context.Background` + unused import | dead code |
| `webservice/main.go` | only gofmt-failing file; `run()` without `ctx`; `defer rt.Close()` | `run(ctx, cfg) error`; `errcheck` |
| `mcp-server` | `context.Background()` under a "Ctrl-C cancels" comment; `log.Printf` then **exit 0** | `assets/README.md`; failed startup looked successful |
| `cli-cobra` | no signal handling | `assets/README.md` |
| `library_test.go` | `tc := tc` | `modern-go.md` (unnecessary since 1.22; every `go.mod` here is ≥ 1.24) |

All six templates: `build`, `vet` and `test -race` green, `gofmt -l` clean.

**Docs**

- `mcp-server.md` documented a handler shape that does not exist in the pinned go-sdk v1.6.1 — `ServerRequest[*CallToolParamsFor[In]]` and `CallToolResultFor[Out]` live only in the SDK's `design/design.md`, the very document cited as the section's source, which fell behind the code before v1.0. Replaced with the real `ToolHandlerFor[In, Out]` plus a note not to copy from `design.md`.
- `testing.md`: `github.com/unknwon/go-mockgen` → `github.com/derision-test/go-mockgen`. The former is a fork with no published module versions.
- `modern-go.md`: the stated reason for running the detector from the skill directory is false for the documented invocation — `go run <abs>/main.go` works fine from inside another module; only the package-directory form fails. Documented the real constraint instead (`go run` compiles in the *target* module's build context).
- `project-layouts.md`: the "multi-command CLI" layout showed three *binaries* (`cmd/root/main.go`, `cmd/add/main.go`, `cmd/remove/main.go`), contradicting `engineering-policy.md` and the repo's own `cli-cobra` template. Split into one binary with a `cmd/` subcommand package, and the genuinely-multiple-binaries case.
- Loop-variable copies dropped from `engineering-policy.md` and `testing.md`; `run()` example now prints its error; evals: `mcp.AddTool` spelling and eval 1's `cmp.Or` expectation for a list-shaped prompt.
- `README.md`: the donor list showed 8 entries under a "nine upstream sources" heading (eino contributes two documents), and "build green with Go 1.26.x" was unverifiable — the `go` directives are 1.24/1.25.

**`.gitignore`** — `assets/README.md` makes `go build ./...` a mandatory gate, so running it leaves `my-tool`, `game` and `mcp-server` in the work tree. The old comment claimed the templates are "not built here", the opposite of what the docs instruct.

## Deliberately not in this PR

These need a decision, not a patch:

- **#1** `<skill-dir>` — picking `${CLAUDE_PLUGIN_ROOT}` vs. reworking the harness table, tied to **#4**.
- **#5** broken links — whether to bring `skills-analysis.md` / `skill-audit-report.md` into the repo or drop the references. All six are untouched.
- **#6.7** Go and dependency versions — raising the `go` directive to 1.26 raises the floor for users, and the cobra/ebiten bumps change `go.sum`. The unverifiable README claim was replaced with one that holds.
- **#8** the `website` drift kind hashing full HTML — noted in the issue as a side note, left as is.
- **#10** CI, and **#11.1** (`docs/` shipping to installed users), **#11.2** (version duplicated in three places), **#11.6** (`Wire()` signature), **#11.7** (`contextx.MergeCancel`).

## Review notes

Five commits, split by area so they can be taken independently. Every claim above was checked against the repo at `aaa86c1` on Go 1.25.6 / darwin-arm64.
