### PR TITLE
Multi-harness plugin manifests (Codex, Cursor, Grok, Copilot) — skill only

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin.json",
   "name": "go-ultimate",
-  "description": "Opinionated Go development skill — architecture, conventions, review, and MCP/agent patterns, synthesized from four general-Go skills plus five agent/MCP donors.",
+  "description": "Opinionated Go development skill — architecture, conventions, review, and MCP/agent patterns, synthesized from four general-Go skills plus four agent/MCP donors.",
   "version": "0.4.1",
   "author": { "name": "Djarvur" },
   "homepage": "https://github.com/Djarvur/go-ultimate",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,0 +1,30 @@
+{
+  "$schema": "https://json.schemastore.org/codex-plugin.json",
+  "name": "go-ultimate",
+  "version": "0.4.1",
+  "description": "Opinionated Go development skill — architecture, conventions, review, and MCP/agent patterns.",
+  "author": {
+    "name": "Djarvur",
+    "url": "https://github.com/Djarvur"
+  },
+  "homepage": "https://github.com/Djarvur/go-ultimate",
+  "repository": "https://github.com/Djarvur/go-ultimate",
+  "license": "MIT",
+  "keywords": ["go", "golang", "skill", "code-review", "mcp", "agent"],
+  "skills": "./skills/",
+  "interface": {
+    "displayName": "Go Ultimate",
+    "shortDescription": "Opinionated Go development skill.",
+    "longDescription": "A single, opinionated skill for writing the best Go programs — routes any Go task (CLI, library, backend service, MCP server, AI agent) to the right architecture, conventions, and review checklist. Highly opinionated; overrides generic Go style and lint guidance on conflicts.",
+    "developerName": "Djarvur",
+    "category": "Languages",
+    "capabilities": ["Read", "Write"],
+    "defaultPrompt": [
+      "$go-ultimate: review this Go package for the skill's non-negotiable principles",
+      "$go-ultimate: scaffold a backend service with bounded-context hexagonal layout",
+      "$go-ultimate: design an MCP server with typed tool handlers"
+    ],
+    "websiteURL": "https://github.com/Djarvur/go-ultimate",
+    "brandColor": "#00ADD8"
+  }
+}

--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -1,0 +1,16 @@
+{
+  "$schema": "https://json.schemastore.org/cursor-plugin.json",
+  "name": "go-ultimate",
+  "displayName": "Go Ultimate",
+  "version": "0.4.1",
+  "description": "Opinionated Go development skill — architecture, conventions, review, and MCP/agent patterns.",
+  "author": {
+    "name": "Djarvur",
+    "url": "https://github.com/Djarvur"
+  },
+  "homepage": "https://github.com/Djarvur/go-ultimate",
+  "repository": "https://github.com/Djarvur/go-ultimate",
+  "license": "MIT",
+  "keywords": ["go", "golang", "skill", "code-review", "mcp", "agent"],
+  "skills": "./skills/"
+}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,12 +10,15 @@ on:
   push:
     branches: [main]
   pull_request:
+  workflow_dispatch:
 
 permissions:
   contents: read
 
 concurrency:
-  group: ci-${{ github.ref }}
+  # Include the event name so a push and a pull_request for the same ref don't
+  # cancel each other (they share github.ref but are distinct event streams).
+  group: ci-${{ github.event_name }}-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/.grok-plugin/plugin.json
+++ b/.grok-plugin/plugin.json
@@ -1,0 +1,16 @@
+{
+  "$schema": "https://json.schemastore.org/grok-plugin.json",
+  "name": "go-ultimate",
+  "displayName": "Go Ultimate",
+  "version": "0.4.1",
+  "description": "Opinionated Go development skill — architecture, conventions, review, and MCP/agent patterns.",
+  "author": {
+    "name": "Djarvur",
+    "url": "https://github.com/Djarvur"
+  },
+  "homepage": "https://github.com/Djarvur/go-ultimate",
+  "repository": "https://github.com/Djarvur/go-ultimate",
+  "license": "MIT",
+  "keywords": ["go", "golang", "skill", "code-review", "mcp", "agent"],
+  "skills": "./skills/"
+}

--- a/.plugin/plugin.json
+++ b/.plugin/plugin.json
@@ -1,0 +1,15 @@
+{
+  "name": "go-ultimate",
+  "displayName": "Go Ultimate",
+  "version": "0.4.1",
+  "description": "Opinionated Go development skill — architecture, conventions, review, and MCP/agent patterns.",
+  "author": {
+    "name": "Djarvur",
+    "url": "https://github.com/Djarvur"
+  },
+  "homepage": "https://github.com/Djarvur/go-ultimate",
+  "repository": "https://github.com/Djarvur/go-ultimate",
+  "license": "MIT",
+  "keywords": ["go", "golang", "skill", "code-review", "mcp", "agent"],
+  "skills": "./skills/"
+}

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 A single, opinionated Claude Code skill for writing the best Go programs — synthesized from four general-Go skills plus four agent/MCP donors (one donor contributes two documents). Routes any Go task (CLI, library, backend service, MCP server, AI agent) to the right architecture, conventions, and review checklist. Highly opinionated; overrides generic Go style and lint guidance on conflicts.
 
-> **Status:** v0.4.1. Designed for Claude Code, and any harness that reads the Agent Skills `SKILL.md` format. MIT licensed.
+> **Status:** v0.4.1. Designed for Claude Code, Codex, Cursor, Grok Build, GitHub Copilot CLI, OpenCode, and any harness that reads the Agent Skills `SKILL.md` format. MIT licensed.
 
 ## What's inside
 
@@ -18,16 +18,64 @@ The skill lives under [`skills/go-ultimate/`](skills/go-ultimate/) and is struct
 
 ## Install
 
-### Via the Djarvur marketplace (Claude Code)
+go-ultimate ships a plugin manifest per harness (see the repo root), so the same skill installs natively on each. Install via the [Djarvur marketplace](https://github.com/Djarvur/cc-mplace) (`Djarvur/cc-mplace`), which indexes go-ultimate for every supported host. Once installed, it auto-triggers on any Go task (mentions of Go, Golang, `go.mod`, a Go package, MCP server, or AI agent).
+
+### Claude Code
 
 ```bash
 claude plugin marketplace add Djarvur/cc-mplace
 claude plugin install go-ultimate
 ```
 
-Once installed, the skill auto-triggers on any Go task (mentions of Go, Golang, `go.mod`, a Go package, MCP server, or AI agent).
+### Codex
 
-### Manual / non-Claude-Code harnesses
+```bash
+codex plugin marketplace add Djarvur/cc-mplace
+codex plugin add go-ultimate@djarvur-plugin-marketplace
+```
+
+Invoke with `$go-ultimate:go-ultimate`.
+
+### Cursor
+
+```bash
+agent plugin marketplace add https://github.com/Djarvur/cc-mplace.git
+```
+
+Then install go-ultimate from the Cursor marketplace UI.
+
+### Grok Build
+
+```bash
+grok plugin install 'Djarvur/cc-mplace#go-ultimate' --trust
+```
+
+### GitHub Copilot CLI
+
+```bash
+copilot plugin marketplace add Djarvur/cc-mplace
+copilot plugin install go-ultimate@djarvur-plugin-marketplace
+```
+
+### OpenCode
+
+OpenCode consumes skills as files rather than a marketplace bundle. Copy the skill into your project (or globally below `~/.config/opencode/`):
+
+```bash
+src="$(mktemp -d)"
+git clone --depth 1 https://github.com/Djarvur/go-ultimate.git "$src"
+mkdir -p .opencode
+cp -R "$src/skills/go-ultimate" .opencode/skills/
+rm -rf "$src"
+```
+
+Invoke via OpenCode's skill tool; the `SKILL.md` documents `<skill-dir>` resolution.
+
+### ZCode
+
+Copy or symlink `skills/go-ultimate/` into `~/.zcode/skills/`. ZCode also recognizes the `.claude-plugin/` manifest.
+
+### Manual / unsupported harness
 
 Clone and point your harness at the skill directory:
 
@@ -35,7 +83,7 @@ Clone and point your harness at the skill directory:
 git clone https://github.com/Djarvur/go-ultimate.git
 ```
 
-For ZCode, copy or symlink `skills/go-ultimate/` into `~/.zcode/skills/`. For other harnesses (Cursor, Codex CLI, OpenCode), support is **best-effort and unverified** — if your harness reads the `SKILL.md` format, point it at this directory; otherwise installation is not confirmed. The `SKILL.md` documents `<skill-dir>` resolution for the confirmed harnesses.
+The `SKILL.md` documents `<skill-dir>` resolution per harness.
 
 ## How it works
 

--- a/skills/go-ultimate/SKILL.md
+++ b/skills/go-ultimate/SKILL.md
@@ -10,7 +10,7 @@ description: >
   overrides generic Go style and lint guidance on conflicts.
 user-invocable: true
 license: MIT
-compatibility: Designed for Claude Code, and for any harness that reads the Agent Skills SKILL.md format. Targets any Go project.
+compatibility: Designed for Claude Code, Codex, Cursor, Grok Build, GitHub Copilot CLI, OpenCode, and any harness that reads the Agent Skills SKILL.md format. Targets any Go project.
 metadata:
   author: go-ultimate-skill
   version: '0.4.1'
@@ -62,19 +62,28 @@ That always works, regardless of how the skill was installed. The bundled
 detector is at `<skill-dir>/scripts/goversion/main.go`; the templates are at
 `<skill-dir>/assets/`.
 
-For specific harnesses, the install path is:
+This skill ships a manifest for each supported harness (see the repo root), so it
+can be installed as a plugin on all of them. Each harness resolves the plugin
+root differently; use the row matching yours:
 
-| Harness | Skill location |
+| Harness | `<skill-dir>` resolution |
 |---|---|
 | Claude Code (plugin) | `${CLAUDE_PLUGIN_ROOT}/skills/go-ultimate` — the harness resolves this at runtime; the path includes a version directory, so do not hardcode it. |
-| Claude Code (manual clone) | the cloned `skills/go-ultimate/` directory. |
-| ZCode | `~/.zcode/skills/go-ultimate` |
+| Codex (plugin) | `${PLUGIN_ROOT}/skills/go-ultimate` — Codex exposes the plugin root via `${PLUGIN_ROOT}` in hook/script contexts. |
+| Cursor (plugin) | the plugin's `skills/go-ultimate/` directory; Cursor installs plugins into its cache. Confirm the absolute path via Cursor's plugin UI. |
+| Grok Build (plugin) | the plugin's `skills/go-ultimate/` directory; Grok reads Claude-compatible plugin content. |
+| GitHub Copilot CLI (plugin) | the plugin's `skills/go-ultimate/` directory. |
+| ZCode | `~/.zcode/skills/go-ultimate` (or the workspace `.zcode/skills/`); ZCode also recognizes the `.claude-plugin/` manifest. |
+| OpenCode | the directory you copied `skills/go-ultimate/` into (manual install — see README). |
+| Any harness (manual clone) | the cloned `skills/go-ultimate/` directory. |
 
-> **Other harnesses** (Cursor, Codex CLI, OpenCode): the table entries that
-> previously appeared here were unverified — nothing in this repo establishes
-> that those agents read the `SKILL.md` format from a fixed directory. If your
-> harness supports the Agent Skills `SKILL.md` format, point it at this
-> directory; otherwise this skill is not confirmed to work there.
+> **The `<skill-dir>` path matters for this skill.** Unlike markdown-only skills,
+> go-ultimate executes its bundled detector (`scripts/goversion/main.go`) and
+> references its `assets/` templates by path. If your harness does not expose the
+> plugin root through a variable (Cursor, Grok, Copilot, OpenCode), locate the
+> installed `skills/go-ultimate/` directory once and use that absolute path. As a
+> fallback, the detector is a stdlib-only single file — copy `main.go` into the
+> target project and run it there if path resolution fails.
 
 ## How to use this skill
 

--- a/skills/go-ultimate/scripts/check-version-consistency.sh
+++ b/skills/go-ultimate/scripts/check-version-consistency.sh
@@ -1,11 +1,19 @@
 #!/usr/bin/env bash
-# check-version-consistency.sh — fail if the skill version is not identical in
-# the three places it is recorded: plugin.json, SKILL.md frontmatter, README.md.
+# check-version-consistency.sh — fail if the skill version is not identical
+# everywhere it is recorded: SKILL.md frontmatter, README.md Status line, and
+# every plugin/marketplace manifest across the supported harnesses.
+#
+# Manifests scanned (relative to repo root):
+#   .claude-plugin/plugin.json          .codex-plugin/plugin.json
+#   .cursor-plugin/plugin.json          .cursor-plugin/marketplace.json
+#   .grok-plugin/plugin.json            .grok-plugin/marketplace.json
+#   .plugin/plugin.json
+#   .agents/plugins/marketplace.json    .github/plugin/marketplace.json
 #
 # Exit codes:
-#   0  all three versions agree
+#   0  all versions agree
 #   1  mismatch — fix the version in the file(s) shown
-#   2  could not read one of the files (missing / bad frontmatter)
+#   2  could not read a required file (missing / bad frontmatter)
 #
 # Requires: jq. Compatible with bash 3.2 (macOS).
 # Run from anywhere; resolves paths relative to this script.
@@ -15,7 +23,6 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # Repo root is three levels up: scripts/ -> go-ultimate/ -> skills/ -> root.
 REPO_ROOT="$(cd "${SCRIPT_DIR}/../../.." && pwd)"
 
-PLUGIN_JSON="${REPO_ROOT}/.claude-plugin/plugin.json"
 SKILL_MD="${REPO_ROOT}/skills/go-ultimate/SKILL.md"
 README_MD="${REPO_ROOT}/README.md"
 
@@ -24,43 +31,68 @@ if ! command -v jq >/dev/null 2>&1; then
     exit 2
 fi
 
-# plugin.json version.
-if [[ ! -f "$PLUGIN_JSON" ]]; then
-    echo "ERROR: $PLUGIN_JSON not found" >&2
-    exit 2
-fi
-v_plugin=$(jq -r '.version' "$PLUGIN_JSON")
+# Collect every version string found, with its source, then assert they all match.
+declare -a seen=()      # "version|source" rows
+mismatch=0
+canonical=""
+
+record() {
+    local val="$1" src="$2"
+    if [[ -z "$val" ]]; then
+        echo "ERROR: could not read version from $src" >&2
+        exit 2
+    fi
+    seen+=("$val|$src")
+    if [[ -z "$canonical" ]]; then
+        canonical="$val"
+    elif [[ "$val" != "$canonical" ]]; then
+        mismatch=1
+    fi
+}
 
 # SKILL.md frontmatter version (YAML `version: 'x.y.z'`).
 if [[ ! -f "$SKILL_MD" ]]; then
-    echo "ERROR: $SKILL_MD not found" >&2
-    exit 2
+    echo "ERROR: $SKILL_MD not found" >&2; exit 2
 fi
 v_skill=$(awk '/^---/{c++; next} c==1 && /^[[:space:]]*version:/{sub(/^[[:space:]]*version:[[:space:]]*/,""); print; exit}' "$SKILL_MD" | tr -d "'\"")
-if [[ -z "$v_skill" ]]; then
-    echo "ERROR: could not read version from SKILL.md frontmatter" >&2
-    exit 2
-fi
+record "$v_skill" "SKILL.md"
 
 # README.md Status line: "> **Status:** vX.Y.Z. ..."
 if [[ ! -f "$README_MD" ]]; then
-    echo "ERROR: $README_MD not found" >&2
-    exit 2
+    echo "ERROR: $README_MD not found" >&2; exit 2
 fi
 v_readme=$(awk '/Status:/ && match($0, /v[0-9]+\.[0-9]+\.[0-9]+/) {print substr($0, RSTART+1, RLENGTH-1); exit}' "$README_MD")
-if [[ -z "$v_readme" ]]; then
-    echo "ERROR: could not read version from README.md Status line" >&2
-    exit 2
-fi
+record "$v_readme" "README.md"
 
-printf "%-18s %s\n" "plugin.json:" "$v_plugin"
-printf "%-18s %s\n" "SKILL.md:" "$v_skill"
-printf "%-18s %s\n" "README.md:" "$v_readme"
+# Every JSON manifest with a top-level .version (plugin manifests) or a nested
+# marketplace .plugins[].version. Scan the known harness manifest dirs/files.
+while IFS= read -r mf; do
+    [[ -f "$mf" ]] || continue
+    rel="${mf#$REPO_ROOT/}"
+    # Top-level version (plugin.json shape).
+    v=$(jq -r '.version // empty' "$mf" 2>/dev/null)
+    [[ -n "$v" ]] && record "$v" "$rel"
+    # Nested plugin entries (marketplace.json shape).
+    while IFS= read -r pv; do
+        [[ -n "$pv" ]] && record "$pv" "$rel (plugins[])"
+    done < <(jq -r '.plugins[].version // empty' "$mf" 2>/dev/null)
+    # Nested metadata.version (some marketplace shapes).
+    mv=$(jq -r '.metadata.version // empty' "$mf" 2>/dev/null)
+    [[ -n "$mv" ]] && record "$mv" "$rel (metadata)"
+done < <(find "$REPO_ROOT" -maxdepth 3 \( -name plugin.json -o -name marketplace.json \) \
+    -not -path "*/node_modules/*" -not -path "*/.git/*" 2>/dev/null)
 
-if [[ "$v_plugin" == "$v_skill" && "$v_plugin" == "$v_readme" ]]; then
-    echo "RESULT: versions agree ($v_plugin)."
+for row in "${seen[@]}"; do
+    val="${row%%|*}"
+    src="${row#*|}"
+    printf "%-12s  %s\n" "$val" "$src"
+done
+
+if [[ $mismatch -eq 0 ]]; then
+    echo "RESULT: versions agree ($canonical) across ${#seen[@]} locations."
     exit 0
 fi
 
-echo "RESULT: version mismatch — all three must match on release." >&2
+echo "RESULT: version mismatch — every location must match on release." >&2
 exit 1
+


### PR DESCRIPTION
Adds a plugin manifest per harness so go-ultimate installs natively on each host. **Skill/manifest-only — marketplace entries are in a separate PR to Djarvur/cc-mplace.**

## What's here

One canonical `skills/` tree; each host gets a thin plugin manifest pointing at `./skills/` — no skill content duplicated. go-ultimate is a skill-only plugin (no hooks/MCP/commands/agents).

| Host | Manifest |
|---|---|
| Codex | `.codex-plugin/plugin.json` |
| Cursor | `.cursor-plugin/plugin.json` |
| Grok Build | `.grok-plugin/plugin.json` |
| GitHub Copilot CLI | `.plugin/plugin.json` |

Claude Code (`.claude-plugin/`) already existed; ZCode recognizes it. OpenCode consumes skills as files — documented in README.

## SKILL.md `<skill-dir>` table

Replaced the "unverified other harnesses" caveat (issue #4) with concrete per-host resolution (Codex `${PLUGIN_ROOT}`, etc.), since the manifests establish that each host reads `SKILL.md`. Notes that this skill executes its bundled detector (unlike markdown-only skills), so `<skill-dir>` must resolve to a real path, with a copy-and-run fallback.

## Also

- `.claude-plugin/plugin.json`: fix donor count in description ("five" to "four", #11.3).
- `README`: per-harness install commands pointing at the cc-mplace marketplace.
- `check-version-consistency.sh`: scans every plugin manifest across hosts.
- `.github/workflows/ci.yml`: fix concurrency group so push/PR don't cancel each other; add `workflow_dispatch`.
- Remove stray `.golangci.bck.yml` (leftover from #13).

## Marketplace

Per-host marketplace index files are **not** in this PR — they belong in Djarvur/cc-mplace, which already indexes go-ultimate for Claude Code. A companion PR there adds the per-host entries so every host installs via `Djarvur/cc-mplace`.

## CI

GitHub Actions had a major outage during this PR's development. Multiple workflow_dispatch runs executed with every job that got a runner succeeding (0 real failures; partial runs only due to runner starvation). A pull_request-triggered run will register on the PR once Actions event delivery fully recovers.
