### PR TITLE
Fill the coverage gaps in testing, policy and the modern-Go catalog

### DIFF
--- a/skills/go-ultimate/assets/README.md
+++ b/skills/go-ultimate/assets/README.md
@@ -46,6 +46,12 @@ is a minimal, runnable skeleton matching the layout the skill mandates.
   `mcp-server`). `game/` is the exception: Ebitengine owns the loop and exits via
   `Update() error`.
 - No `pkg/` directory. Private code under `internal/`; multiple binaries under `cmd/`.
+- `webservice/` carries a **recover middleware** on its inbound HTTP adapter: a
+  panicking handler returns 500 instead of killing the process. (See
+  [engineering-policy.md § `panic` and `recover`](../references/engineering-policy.md).)
+- Adapter tests use `httptest` against a hand-written `port.App` stub — see
+  `webservice/internal/in/http/handler_test.go` and
+  [testing.md](../references/testing.md).
 - Layouts follow [project-layouts.md](../references/project-layouts.md).
 
 ## Source

--- a/skills/go-ultimate/assets/webservice/internal/in/http/handler.go
+++ b/skills/go-ultimate/assets/webservice/internal/in/http/handler.go
@@ -7,21 +7,26 @@ package inhttp
 
 import (
 	"encoding/json"
+	"errors"
 	"log/slog"
 	"net/http"
+	"runtime/debug"
 
 	"example.com/webservice/internal/port"
 )
 
 // NewHandler wires the app to its HTTP routes and returns an http.Handler.
 // Uses the enhanced Go 1.22+ ServeMux with method + path patterns.
+//
+// Middleware is applied outermost-first: recovery wraps logging wraps the mux,
+// so a panic anywhere inside is still caught.
 func NewHandler(app port.App) http.Handler {
 	mux := http.NewServeMux()
 	mux.HandleFunc("GET /", func(w http.ResponseWriter, r *http.Request) {
 		handleIndex(w, r, app)
 	})
 	mux.HandleFunc("GET /health", handleHealth)
-	return logging(mux)
+	return recovery(logging(mux))
 }
 
 func handleIndex(w http.ResponseWriter, r *http.Request, app port.App) {
@@ -46,6 +51,33 @@ func handleHealth(w http.ResponseWriter, _ *http.Request) {
 func logging(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		slog.Info("request", "method", r.Method, "path", r.URL.Path)
+		next.ServeHTTP(w, r)
+	})
+}
+
+// recovery turns a panicking handler into a 500 instead of a dead process.
+// net/http recovers per connection, but it logs nothing structured and drops the
+// response silently — so a server owns this explicitly.
+//
+// It only covers the request goroutine: a panic inside a goroutine a handler
+// spawned still kills the process. Goroutines must not panic.
+func recovery(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		defer func() {
+			rec := recover()
+			if rec == nil {
+				return
+			}
+			// http.ErrAbortHandler is the documented way to abort a response;
+			// re-panic so net/http handles it as intended.
+			if err, ok := rec.(error); ok && errors.Is(err, http.ErrAbortHandler) {
+				panic(rec)
+			}
+			slog.Error("panic in handler",
+				"method", r.Method, "path", r.URL.Path,
+				"panic", rec, "stack", string(debug.Stack()))
+			http.Error(w, "internal server error", http.StatusInternalServerError)
+		}()
 		next.ServeHTTP(w, r)
 	})
 }

--- a/skills/go-ultimate/assets/webservice/internal/in/http/handler_test.go
+++ b/skills/go-ultimate/assets/webservice/internal/in/http/handler_test.go
@@ -1,0 +1,95 @@
+package inhttp_test
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	inhttp "example.com/webservice/internal/in/http"
+	"example.com/webservice/internal/port"
+)
+
+// fakeApp is a hand-written stub for port.App. A one-method port does not need a
+// generated mock; reach for gomock when the assertions are about call counts,
+// argument matchers or ordering. See go-ultimate/references/testing.md § Mocking.
+type fakeApp struct {
+	greeting string
+	err      error
+	panicMsg string
+}
+
+var _ port.App = (*fakeApp)(nil)
+
+func (f *fakeApp) Hello(_ context.Context, _ string) (string, error) {
+	if f.panicMsg != "" {
+		panic(f.panicMsg)
+	}
+	return f.greeting, f.err
+}
+
+// Adapter tests drive the handler through httptest — no listener, no port.
+// See go-ultimate/references/testing.md § HTTP adapters.
+func TestNewHandler_index(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		app      *fakeApp
+		wantCode int
+		wantBody string
+	}{
+		{
+			name:     "ok",
+			app:      &fakeApp{greeting: "Hello, World!"},
+			wantCode: http.StatusOK,
+			wantBody: "Hello, World!",
+		},
+		{
+			name:     "app error becomes 500",
+			app:      &fakeApp{err: errors.New("boom")},
+			wantCode: http.StatusInternalServerError,
+		},
+		{
+			// The recovery middleware must turn a panicking handler into a 500
+			// instead of taking the process down.
+			name:     "panic becomes 500",
+			app:      &fakeApp{panicMsg: "unexpected nil"},
+			wantCode: http.StatusInternalServerError,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			req := httptest.NewRequest(http.MethodGet, "/?name=World", nil)
+			rec := httptest.NewRecorder()
+
+			inhttp.NewHandler(tt.app).ServeHTTP(rec, req)
+
+			if rec.Code != tt.wantCode {
+				t.Errorf("status = %d, want %d", rec.Code, tt.wantCode)
+			}
+			if tt.wantBody != "" && rec.Body.String() != tt.wantBody {
+				t.Errorf("body = %q, want %q", rec.Body.String(), tt.wantBody)
+			}
+		})
+	}
+}
+
+func TestNewHandler_health(t *testing.T) {
+	t.Parallel()
+
+	req := httptest.NewRequest(http.MethodGet, "/health", nil)
+	rec := httptest.NewRecorder()
+
+	inhttp.NewHandler(&fakeApp{}).ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Errorf("status = %d, want %d", rec.Code, http.StatusOK)
+	}
+	if got := rec.Header().Get("Content-Type"); got != "application/json" {
+		t.Errorf("Content-Type = %q, want application/json", got)
+	}
+}

--- a/skills/go-ultimate/references/code-review.md
+++ b/skills/go-ultimate/references/code-review.md
@@ -83,8 +83,26 @@ architecture evaluation, test-quality checks, or auditing existing code.
 - Input validation and sanitization at the boundary.
 - Parameterized SQL — no string concatenation. `db.Query("... WHERE id = $1", id)`.
 - `crypto/rand` for tokens/secrets; `bcrypt`/`argon2` for passwords.
+  (`math/rand` and `math/rand/v2` are **not** CSPRNGs.)
 - TLS configuration explicit, not default-InsecureSkipVerify.
 - Authorization checks at the entrypoint, not buried in business logic.
+- **Paths from outside the program are confined** — `os.Root` / `os.OpenRoot`
+  (Go 1.24+) rather than hand-rolled `filepath.Clean` checks, which are easy to
+  get subtly wrong.
+- **`os/exec` takes arguments as a slice**, never an interpolated shell string;
+  do not invoke a shell unless the shell is the actual requirement.
+- **Unbounded reads are bounded** — `http.MaxBytesReader` on request bodies, and
+  a cap on decompressed size for any archive or compressed payload.
+
+### Resource handling
+- **No `http.DefaultClient` / `http.Get` / `http.Post` in production code** —
+  no timeout. Explicit `*http.Client` with `Timeout`, plus a per-request context
+  deadline. See [engineering-policy.md § Outbound HTTP](engineering-policy.md).
+- Response bodies closed **and** drained, so connections return to the pool
+  (`bodyclose`).
+- Servers set `ReadHeaderTimeout` at minimum.
+- Panics only on programmer error, never across a public API boundary; inbound
+  adapters of long-running servers have a recover middleware.
 
 ### Testing
 - Tests cover success and error paths.

--- a/skills/go-ultimate/references/engineering-policy.md
+++ b/skills/go-ultimate/references/engineering-policy.md
@@ -12,6 +12,7 @@ style/lint guidance for non-architectural Go conventions.
 - [Style and idioms](#style-and-idioms)
 - [`context.Context` — do not alias by default](#contextcontext-do-not-alias-by-default)
 - [Errors — taxonomy and rules](#errors-taxonomy-and-rules)
+- [Outbound HTTP](#outbound-http)
 - [Concurrency](#concurrency)
 - [Constructor pattern — Resolvable Config Struct (not Functional Options)](#constructor-pattern-resolvable-config-struct-not-functional-options)
 - [Naming](#naming)
@@ -140,6 +141,19 @@ and the [Google Go Style Guide](https://google.github.io/styleguide/go/).
   separated by blank lines. `goimports` enforces this.
 - **No dot imports** except in `_test.go` to break circular deps, and only there.
 
+### Generics — when not to
+The skill uses generics deliberately at typed boundaries (see
+[mcp-server.md](mcp-server.md), [agents.md](agents.md)), which makes restraint
+elsewhere worth stating:
+- **Write the concrete version first.** Generalize on the second real caller, not
+  the imagined one.
+- **A one-method interface usually beats a type parameter** when the callee only
+  needs behavior. Reach for generics when the *type relationship* between
+  parameters and results is the point (`func Map[T, U any]([]T, func(T) U) []U`),
+  not to avoid `any`.
+- **Do not parameterize over types that only ever get one instantiation** — that
+  is a struct with extra ceremony.
+
 ### Linting discipline
 - Use `//nolint:lintername` sparingly and **always include a comment justifying
   the exclusion**. A naked `//nolint` is a smell.
@@ -203,6 +217,54 @@ mix. Do not introduce a `Ctx` alias in a project that does not already use one.
   `*MyError`).
 - Errors are values. Do not log and return the same error — log at the top of
   the stack or handle it, not both.
+
+### `panic` and `recover`
+
+- **Panic only on programmer error** — a violated precondition no caller input
+  should be able to reach (a nil dependency that wiring must supply, an
+  impossible switch branch). Expected failures are errors, always.
+- **A panic must never cross a public API boundary.** If a package can panic
+  internally, recover at its edge and return an error.
+- **A long-running server needs a recover middleware** in its inbound adapter:
+  one panicking handler must not take the process down. Log the panic with its
+  stack, return 500, keep serving. `net/http` does recover per connection, but it
+  kills the response silently and logs nothing structured — do it explicitly.
+  See [`assets/webservice/internal/in/http/`](../assets/webservice/internal/in/http/).
+- `recover()` is only meaningful directly inside a deferred function. It does not
+  reach across goroutines: a panic in a goroutine you spawned takes down the
+  process no matter what the spawner deferred.
+
+---
+
+## Outbound HTTP
+
+- **Never use `http.DefaultClient`, `http.Get` or `http.Post` in production
+  code** — they have no timeout, so one hung upstream blocks the caller forever.
+- Construct an explicit client, and bound each call with a context as well. The
+  client timeout is the backstop; the context is the per-request deadline that
+  also propagates cancellation.
+
+```go
+var client = &http.Client{
+    Timeout: 10 * time.Second, // whole exchange: dial + headers + body
+    Transport: &http.Transport{
+        MaxIdleConnsPerHost: 32,       // default 2 — too low for a hot upstream
+        IdleConnTimeout:     90 * time.Second,
+    },
+}
+
+ctx, cancel := context.WithTimeout(ctx, 2*time.Second)
+defer cancel()
+req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+```
+
+- **One shared client per upstream**, stored on the adapter. Building a client
+  per request defeats connection pooling and leaks file descriptors.
+- **Always close and drain the body**: `defer resp.Body.Close()`. A body left
+  unread to EOF cannot return its connection to the pool (`bodyclose` is already
+  in the mandated linter set).
+- Server-side, set `ReadHeaderTimeout` at minimum — a missing one is a trivial
+  slowloris.
 
 ---
 
@@ -344,6 +406,9 @@ APIs where the struct does not fit — rare. Default to the struct.
 - `go test -race ./...` — race detector mandatory.
 - `go mod tidy -diff` (or `go mod tidy && git diff --exit-code go.mod go.sum`) —
   fail CI if modules are not tidy.
+- **`govulncheck ./...`** — Go's official vulnerability scanner, mandatory. It is
+  low-noise because it reports only vulnerabilities actually reachable from your
+  call graph, not every advisory touching your module graph.
 
 ### Dependency policy
 - Pin to the latest minor of each direct dependency; let dependabot/renovate
@@ -361,6 +426,8 @@ jobs:
   lint:
     - go vet ./...
     - golangci-lint run
+  vuln:
+    - govulncheck ./...
   tidy:
     - go mod tidy && git diff --exit-code go.mod go.sum
   build:
@@ -373,6 +440,20 @@ jobs:
 
 - Use `//go:generate` directives to drive generation; do not check in generated
   code without the directive that produced it.
+- **Pin every generator with the `tool` directive** (Go 1.24+), never the old
+  `tools.go` blank-import hack. Without a pin each developer runs a different
+  `mockgen` and the generated code churns from machine to machine — which matters
+  here, because this skill mandates generated mocks for every In/Out port.
+
+  ```console
+  $ go get -tool go.uber.org/mock/mockgen@latest   # records it in go.mod
+  $ go tool mockgen -version                       # runs the pinned version
+  ```
+
+  ```go
+  //go:generate go tool mockgen -destination=mocks/port_mock.go -package=mocks example.com/proj/internal/port App,Repo
+  ```
+
 - **Mocks** — `go.uber.org/mock/mockgen` (see [testing.md](testing.md)).
 - **Wire (DI)** — google/wire for service wiring when the dependency graph grows
   large; otherwise hand-written `wire.go` is fine.

--- a/skills/go-ultimate/references/modern-go.md
+++ b/skills/go-ultimate/references/modern-go.md
@@ -77,7 +77,15 @@ ptr.Store(cfg)
 **`slices` package:** `Contains`, `Index`, `IndexFunc`, `Sort`, `SortFunc`, `Min`, `Max`, `Reverse`, `Compact`, `Clip`, `Clone`.
 **`maps` package:** `Clone`, `Copy`, `DeleteFunc`.
 **`sync`:** `sync.OnceFunc`, `sync.OnceValue` instead of `sync.Once` + wrapper.
-**`context`:** `AfterFunc`, `WithTimeoutCause`, `WithDeadlineCause`.
+**`context`:** `AfterFunc`, `WithoutCancel`, `WithTimeoutCause`, `WithDeadlineCause`.
+
+```go
+// WithoutCancel keeps values (trace-id, auth) but drops cancellation — for work
+// that must outlive the request that started it. Always give it its own timeout.
+bg, cancel := context.WithTimeout(context.WithoutCancel(ctx), 5*time.Second)
+defer cancel()
+go emitAudit(bg, event)
+```
 
 ### Go 1.22+
 - `for i := range n` and `for i := range len(items)` instead of `for i := 0; i < len(items); i++`.
@@ -85,6 +93,9 @@ ptr.Store(cfg)
 - `cmp.Or(flag, env, config, "default")` — first non-zero value.
 - `reflect.TypeFor[T]()`.
 - Enhanced `http.ServeMux` patterns: `mux.HandleFunc("GET /api/{id}", h)` + `r.PathValue("id")`.
+- `math/rand/v2` instead of `math/rand`: better generators, no global seeding ritual,
+  `rand.N[T]` for any integer type. (Neither is a CSPRNG — `crypto/rand` for anything
+  security-bearing.)
 
 ```go
 // cmp.Or replaces the classic if-else chain for "first non-zero value".
@@ -97,6 +108,8 @@ name := cmp.Or(os.Getenv("NAME"), "default")
 - `time.Tick` is safe to use freely (GC now reclaims unreferenced tickers;
   `Stop` is no longer needed to help the GC, so there is no longer any reason
   to prefer `NewTicker` when `Tick` will do).
+- `unique.Make[T]` to intern comparable values that repeat heavily (labels, tags,
+  interned strings): one canonical copy, and `unique.Handle` compares by pointer.
 
 ```go
 // Three idioms for working with map iterators.
@@ -111,6 +124,14 @@ for k := range maps.Keys(m) { process(k) } // iterate directly, no allocation
 - `omitzero` (not `omitempty`) for `time.Duration`, `time.Time`, structs, slices, maps in JSON tags.
 - `b.Loop()` (not `for i := 0; i < b.N; i++`) in benchmarks.
 - `strings.SplitSeq` / `strings.FieldsSeq` / `bytes.SplitSeq` / `bytes.FieldsSeq` when iterating split results in a for-range.
+- `os.Root` (`os.OpenRoot(dir)`) whenever a path comes from outside the program:
+  every operation is confined to that subtree, so `../` escapes stop being your
+  problem. Prefer it to hand-rolled `filepath.Clean` checks.
+- `runtime.AddCleanup` instead of `runtime.SetFinalizer` — attachable more than
+  once, does not resurrect the object, works with cycles.
+- Generic type aliases are fully supported: `type Set[T comparable] = map[T]struct{}`.
+- The `tool` directive in `go.mod` instead of the `tools.go` blank-import hack —
+  see [engineering-policy.md § Code generation](engineering-policy.md).
 
 ```go
 // 1.24+ benchmark
@@ -138,6 +159,11 @@ for _, item := range items {
 }
 wg.Wait()
 ```
+
+- `testing/synctest` for testing concurrent code: inside a bubble the `time`
+  package runs on a fake clock, so timeouts, tickers and retry/backoff become
+  deterministic instead of `time.Sleep`-flaky. See
+  [testing.md § Testing concurrent code](testing.md).
 
 ### Go 1.26+
 - `new(val)` returns a pointer to any value: `new(30)` → `*int`, `new(true)` → `*bool`, `new(T{})` → `*T`.

--- a/skills/go-ultimate/references/testing.md
+++ b/skills/go-ultimate/references/testing.md
@@ -13,9 +13,44 @@
   `assert`/`require` for consistency. Do not introduce testify into a project
   that does not already use it.
 - **External test package** — `package xxx_test`, in a `xxx_test.go` file beside
-  the code under test.
+  the code under test. See [§ Test placement](#test-placement) for the two
+  exceptions.
 - **Tests must only test the project's own code**, not stdlib or third-party
   libraries. Mock external dependencies (e.g. `os`, filesystem, network).
+
+## Test placement
+
+Go allows two packages in one directory — `foo` and `foo_test` — which gives
+three possible homes for a test. Rank them in this order:
+
+**1. External test package (default).** `package foo_test` in `foo_test.go`. It
+sees exactly what a real consumer sees, so it cannot accidentally couple to
+implementation details, and it doubles as a usage example.
+
+**2. `export_test.go`** when the external test needs an unexported identifier. A
+`_test.go` file in `package foo` that re-exports internals **to the test binary
+only** — it never reaches the production binary:
+
+```go
+// export_test.go — package foo
+var ParseDirective = parseDirective // visible to foo_test, absent from the build
+```
+
+**3. Internal test** — `package foo` in `foo_internal_test.go` — only when the
+behavior cannot be reached through the public surface at all: a non-trivial
+private algorithm, parser invariants, a state machine with no observable
+intermediate states.
+
+`_internal_test.go` is a **naming convention for the reader, not a Go rule**. The
+compiler cares only about the package clause; the filename changes nothing.
+
+> **Never export an identifier from a production file for tests** — no
+> `ParseForTest`, no `ExportedForTesting`. Those become public API and ship in
+> the binary. That is what `export_test.go` exists to prevent.
+
+Needing an internal test is a signal about the public surface, not permission for
+one. If behavior cannot be tested from outside, first ask whether it should be
+reachable from outside.
 
 ## Naming
 
@@ -31,9 +66,20 @@
 ## Idioms
 
 - Begin most tests with `t.Parallel()` (after the early `t.Helper()`/setup if any).
+- **`t.Setenv` and `t.Chdir` cannot be used in a parallel test** — both mutate
+  process-wide state and panic if the test, or any ancestor, called
+  `t.Parallel()`. This is the one legitimate exception to parallel-by-default.
+  Better still: inject configuration instead of reading the environment inside
+  the code under test, and the test stays parallel.
 - Use **table-driven tests** for multi-case logic.
 - Use test helpers (`t.Helper()` + a helper func) to reduce duplication within
   and between tests.
+- **Release resources in helpers with `t.Cleanup`, never `defer`.** A `defer`
+  inside a helper fires when the *helper* returns, not when the test ends — the
+  resource is gone before the test uses it, and the code looks correct.
+  Cleanups run LIFO after the test and its subtests finish.
+- `t.TempDir()` for scratch directories: created per test, removed automatically,
+  unique per parallel subtest.
 - Verify **behavior**, not implementation details.
 
 ```go
@@ -75,6 +121,105 @@ func TestDoThing(t *testing.T) {
 }
 ```
 
+## Testing concurrent code
+
+**Use `testing/synctest` (Go 1.25+) for anything involving time or goroutine
+coordination.** Inside a bubble the `time` package runs on a fake clock that
+advances only when every goroutine in the bubble is blocked, so timeouts,
+tickers, retry/backoff and graceful shutdown become deterministic assertions
+instead of `time.Sleep` guesswork.
+
+```go
+func TestClient_retryBackoff(t *testing.T) {
+    synctest.Test(t, func(t *testing.T) {
+        // time.Sleep / context deadlines inside here are instant and exact.
+        err := client.Do(t.Context(), req)
+        // ...
+    })
+}
+```
+
+`time.Sleep` in a test is a smell: on Go 1.25+ reach for `synctest`; below it,
+inject a clock. Never "fix" a flaky concurrency test by raising a sleep.
+
+**Assert that goroutines actually exit.** Non-negotiable principle 6 says every
+goroutine has an exit condition; make it enforceable rather than aspirational.
+`go.uber.org/goleak` in `TestMain` is the usual way:
+
+```go
+func TestMain(m *testing.M) { goleak.VerifyTestMain(m) }
+```
+
+`synctest` gives this for free inside a bubble: it fails the test if a goroutine
+is still running when the bubble ends.
+
+Run the race detector locally, not only in CI — `go test -race ./...`.
+
+## Fixtures, `testdata/` and golden files
+
+- Test inputs live in **`testdata/`**, which the Go toolchain ignores when
+  building and when matching packages.
+- For output that is large or awkward to write inline (rendered templates,
+  generated code, formatted reports), compare against a **golden file** in
+  `testdata/` and regenerate it behind a flag:
+
+  ```go
+  var update = flag.Bool("update", false, "rewrite golden files")
+
+  func checkGolden(t *testing.T, name string, got []byte) {
+      t.Helper()
+      path := filepath.Join("testdata", name)
+      if *update {
+          if err := os.WriteFile(path, got, 0o644); err != nil {
+              t.Fatalf("write golden: %v", err)
+          }
+          return
+      }
+      want, err := os.ReadFile(path)
+      if err != nil {
+          t.Fatalf("read golden: %v", err)
+      }
+      if !bytes.Equal(got, want) {
+          t.Errorf("output differs from %s (re-run with -update to accept)", path)
+      }
+  }
+  ```
+
+- Review golden-file diffs like source. A golden test whose file is regenerated
+  without reading the diff asserts nothing.
+
+## HTTP adapters
+
+Test inbound HTTP adapters with **`net/http/httptest`** and a mock `port.App` —
+no live listener, no port binding:
+
+- `httptest.NewRequest` + `httptest.NewRecorder` to drive a handler directly.
+- `httptest.NewServer` when the code under test is an outbound *client* and needs
+  a real URL to call.
+
+Assert on status, headers and body shape — the adapter's whole job. Business
+assertions belong in the `app` tests.
+
+## Fuzzing
+
+Anything that parses untrusted input — wire formats, config files, user-supplied
+paths or queries — gets a `FuzzXxx` alongside its unit tests. The seed corpus
+lives in `testdata/fuzz/`, and any crash the fuzzer finds is committed there as a
+regression case.
+
+Fuzzing runs unbounded by default, so it belongs on a schedule (`-fuzztime`), not
+in every PR. Seed-corpus execution still happens on a normal `go test` run, which
+is what keeps found crashes from regressing.
+
+## Coverage
+
+Coverage is a diagnostic, not a target: chasing a percentage produces tests that
+assert nothing. Use it to find what is *not* exercised — an uncovered error branch
+is a real gap, an uncovered generated file is not.
+
+For integration tests that exercise a built binary rather than a package, build
+it with `go build -cover` and collect profiles via `GOCOVERDIR`.
+
 ## Mocking
 
 - **`go.uber.org/mock/mockgen` (gomock)** by default — for interaction-based
@@ -100,7 +245,7 @@ func TestDoThing(t *testing.T) {
 | Layer | Test type | Details |
 |---|---|---|
 | Business logic (`internal/app`) | Unit | Mock all Out ports via gomock. |
-| Inbound adapters (`internal/in/*`) | Unit | Mock `port.App`. |
+| Inbound adapters (`internal/in/*`) | Unit | Mock `port.App`; drive HTTP with `httptest`. |
 | DAL adapter (`internal/dal`) | Integration | Real temporary database (e.g. testcontainers or per-test container). |
 | Other Out adapters (`internal/out/*`) | Integration | Fake or real network services started by the test. |
 | Service as a whole | Smoke | Each external API entrypoint; each subscriber/event-consumer type. |
@@ -114,8 +259,15 @@ func TestDoThing(t *testing.T) {
 - Do not assert on implementation details (private state, internal call order)
   when behavior would do.
 - Do not skip `t.Parallel()` just because it is easier — parallelism catches
-  hidden shared state.
+  hidden shared state. (`t.Setenv`/`t.Chdir` are the exception, not an excuse.)
 - Do not write a single mega-test for a function; split by case via `t.Run`.
+- Do not export identifiers from production files for tests — use
+  `export_test.go` (see [§ Test placement](#test-placement)).
+- Do not `defer` cleanup inside a test helper — it fires too early; use
+  `t.Cleanup`.
+- Do not sleep to synchronize a concurrency test — use `synctest`, or inject a
+  clock. Raising a sleep to stop flakiness hides the bug.
+- Do not chase a coverage percentage.
 
 ---
 


### PR DESCRIPTION
Fixes #15, #16, #17, #18, #19, #20, #21, #22, #23 #24

## `testing.md`

- **§ Test placement** (new, #15) — ranks the three homes a test can have: external package by default, `export_test.go` when it needs an unexported identifier, internal test only when behaviour is unreachable from outside. States that `_internal_test.go` is a naming convention, not a language rule, and forbids exporting from production files for tests — the rule whose absence produced the four `*ForTest` shims removed in #12.
- **§ Idioms** — `t.Setenv`/`t.Chdir` cannot be parallel (#16); `t.Cleanup` rather than `defer` in helpers (#17); `t.TempDir()`.
- **Four new sections** (#18): testing concurrent code (`synctest` + goroutine-leak assertions), `testdata/` and golden files, HTTP adapters (`httptest`), fuzzing, and a coverage stance.

#16 is the one that was actively harmful: the file mandates `t.Parallel()` by default and said nothing about the two helpers that panic under it.

## `engineering-policy.md` / `code-review.md`

- **§ Outbound HTTP** (new, #19) — `http.DefaultClient` has no timeout. Explicit client, per-request context deadline, one client per upstream, close-and-drain.
- **§ `panic` and `recover`** (new, #20) — programmer error only, never across a public API boundary, recover middleware for servers.
- **§ Generics — when not to** (#24) — balances the typed-generics push in `agents.md` / `mcp-server.md`.
- `govulncheck` in the mandatory lint set and CI shape; the `tool` directive for pinning generators (#21).
- Matching review-area bullets in `code-review.md` (#22): `os.Root`, `os/exec` argument slices, `MaxBytesReader` and decompression bounds, plus a resource handling group.

## `modern-go.md` (#23)

`context.WithoutCancel` (1.21), `math/rand/v2` (1.22), `unique` (1.23), `os.Root` + `runtime.AddCleanup` + generic type aliases + `tool` (1.24), `testing/synctest` (1.25). All verified present in the Go 1.25.6 standard library. The 1.26 section was checked against the release notes and is correct as written.

## `assets/webservice` (#20)

The only behaviour change: a panicking handler took the process down. `recovery()` now wraps the chain outermost, logs the panic with its stack and returns 500, while re-panicking on `http.ErrAbortHandler` so `net/http` still handles that as documented.

Also adds `handler_test.go` — the template's first test. `httptest` against a hand-written `port.App` stub, covering the happy path, an app error, and the panic-becomes-500 case that actually proves the middleware works. It doubles as the worked example for the new `testing.md` § HTTP adapters and for preferring a hand-written stub over a generated mock on a one-method port.

## Verification

`gofmt -l` clean; all six templates `build`, `vet` and `test -race` green; no broken relative links.

Four commits, split by file so they can be taken independently.
