### PR TITLE
release: v0.10.0 — bump version, set author, list maintainers

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin.json",
   "name": "go-ultimate",
   "description": "Opinionated Go development skill — architecture, conventions, review, and MCP/agent patterns, synthesized from four general-Go skills plus four agent/MCP donors.",
-  "version": "0.4.1",
+  "version": "0.10.0",
   "author": { "name": "Djarvur" },
   "homepage": "https://github.com/Djarvur/go-ultimate",
   "repository": "https://github.com/Djarvur/go-ultimate",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/codex-plugin.json",
   "name": "go-ultimate",
-  "version": "0.4.1",
+  "version": "0.10.0",
   "description": "Opinionated Go development skill — architecture, conventions, review, and MCP/agent patterns.",
   "author": {
     "name": "Djarvur",

--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/cursor-plugin.json",
   "name": "go-ultimate",
   "displayName": "Go Ultimate",
-  "version": "0.4.1",
+  "version": "0.10.0",
   "description": "Opinionated Go development skill — architecture, conventions, review, and MCP/agent patterns.",
   "author": {
     "name": "Djarvur",

--- a/.grok-plugin/plugin.json
+++ b/.grok-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/grok-plugin.json",
   "name": "go-ultimate",
   "displayName": "Go Ultimate",
-  "version": "0.4.1",
+  "version": "0.10.0",
   "description": "Opinionated Go development skill — architecture, conventions, review, and MCP/agent patterns.",
   "author": {
     "name": "Djarvur",

--- a/.plugin/plugin.json
+++ b/.plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "go-ultimate",
   "displayName": "Go Ultimate",
-  "version": "0.4.1",
+  "version": "0.10.0",
   "description": "Opinionated Go development skill — architecture, conventions, review, and MCP/agent patterns.",
   "author": {
     "name": "Djarvur",

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 A single, opinionated Claude Code skill for writing the best Go programs — synthesized from four general-Go skills plus four agent/MCP donors (one donor contributes two documents). Routes any Go task (CLI, library, backend service, MCP server, AI agent) to the right architecture, conventions, and review checklist. Highly opinionated; overrides generic Go style and lint guidance on conflicts.
 
-> **Status:** v0.4.1. Designed for Claude Code, Codex, Cursor, Grok Build, GitHub Copilot CLI, OpenCode, and any harness that reads the Agent Skills `SKILL.md` format. MIT licensed.
+> **Status:** v0.10.0. Designed for Claude Code, Codex, Cursor, Grok Build, GitHub Copilot CLI, OpenCode, and any harness that reads the Agent Skills `SKILL.md` format. MIT licensed.
 
 ## What's inside
 

--- a/skills/go-ultimate/SKILL.md
+++ b/skills/go-ultimate/SKILL.md
@@ -12,8 +12,13 @@ user-invocable: true
 license: MIT
 compatibility: Designed for Claude Code, Codex, Cursor, Grok Build, GitHub Copilot CLI, OpenCode, and any harness that reads the Agent Skills SKILL.md format. Targets any Go project.
 metadata:
-  author: go-ultimate-skill
-  version: '0.4.1'
+  author: Djarvur
+  version: '0.10.0'
+  maintainers:
+    - name: Daniel Podolsky
+      url: https://github.com/onokonem
+    - name: Olga Pichuzhkina
+      url: https://github.com/vyhuholl
   sources:
     - teetsh-org/claude-skills#golang-code-review
     - JetBrains/go-modern-guidelines#use-modern-go


### PR DESCRIPTION
## Summary

Bumps the skill from **0.4.1 → 0.10.0** and corrects the author/maintainers metadata.

### Version bump (0.4.1 → 0.10.0)
Touches all **seven** locations guarded by `check-version-consistency.sh` (the same check `ci.yml:version-consistency` runs):

- `skills/go-ultimate/SKILL.md` — `metadata.version`
- `README.md` — Status line
- `.plugin/plugin.json`
- `.claude-plugin/plugin.json`
- `.cursor-plugin/plugin.json`
- `.codex-plugin/plugin.json`
- `.grok-plugin/plugin.json`

### Author / maintainers
- `SKILL.md` `metadata.author`: `go-ultimate-skill` (placeholder) → **`Djarvur`**, matching the MIT copyright holder and the publishing entity already named in every plugin manifest.
- Adds `metadata.maintainers`: **Daniel Podolsky** (\@onokonem) and **Olga Pichuzhkina** (\@vyhuholl) — the individual contributors from git history.

## Verification
```
$ bash skills/go-ultimate/scripts/check-version-consistency.sh
0.10.0   SKILL.md
0.10.0   README.md
0.10.0   .cursor-plugin/plugin.json
0.10.0   .plugin/plugin.json
0.10.0   .claude-plugin/plugin.json
0.10.0   .codex-plugin/plugin.json
0.10.0   .grok-plugin/plugin.json
RESULT: versions agree (0.10.0) across 7 locations.   (exit 0)
```
SKILL.md frontmatter re-validated as parseable YAML; all five plugin manifests re-validated as JSON with `jq`.

## After merge
This merge commit will be tagged **v0.10.0** and released.