### PR TITLE
Harvest metalagman/agent-skills + Google/Uber style guides → v0.11.0

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,8 +1,8 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-plugin.json",
   "name": "go-ultimate",
-  "description": "Opinionated Go development skill — architecture, conventions, review, and MCP/agent patterns, synthesized from four general-Go skills plus four agent/MCP donors.",
-  "version": "0.10.0",
+  "description": "Opinionated Go development skill — architecture, conventions, production readiness, repo/CI hygiene, review, and MCP/agent patterns.",
+  "version": "0.11.0",
   "author": { "name": "Djarvur" },
   "homepage": "https://github.com/Djarvur/go-ultimate",
   "repository": "https://github.com/Djarvur/go-ultimate",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/codex-plugin.json",
   "name": "go-ultimate",
-  "version": "0.10.0",
+  "version": "0.11.0",
   "description": "Opinionated Go development skill — architecture, conventions, review, and MCP/agent patterns.",
   "author": {
     "name": "Djarvur",

--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/cursor-plugin.json",
   "name": "go-ultimate",
   "displayName": "Go Ultimate",
-  "version": "0.10.0",
+  "version": "0.11.0",
   "description": "Opinionated Go development skill — architecture, conventions, review, and MCP/agent patterns.",
   "author": {
     "name": "Djarvur",

--- a/.grok-plugin/plugin.json
+++ b/.grok-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/grok-plugin.json",
   "name": "go-ultimate",
   "displayName": "Go Ultimate",
-  "version": "0.10.0",
+  "version": "0.11.0",
   "description": "Opinionated Go development skill — architecture, conventions, review, and MCP/agent patterns.",
   "author": {
     "name": "Djarvur",

--- a/.plugin/plugin.json
+++ b/.plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "go-ultimate",
   "displayName": "Go Ultimate",
-  "version": "0.10.0",
+  "version": "0.11.0",
   "description": "Opinionated Go development skill — architecture, conventions, review, and MCP/agent patterns.",
   "author": {
     "name": "Djarvur",

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # go-ultimate
 
-A single, opinionated Claude Code skill for writing the best Go programs — synthesized from four general-Go skills plus four agent/MCP donors (one donor contributes two documents). Routes any Go task (CLI, library, backend service, MCP server, AI agent) to the right architecture, conventions, and review checklist. Highly opinionated; overrides generic Go style and lint guidance on conflicts.
+A single, opinionated Claude Code skill for writing the best Go programs — synthesized from four general-Go skills, four agent/MCP donors (one donor contributes two documents), the Google and Uber style guides, and a repository/production-practice donor. Routes any Go task (CLI, library, backend service, MCP server, AI agent) to the right architecture, conventions, and review checklist. Highly opinionated; overrides generic Go style and lint guidance on conflicts.
 
-> **Status:** v0.10.0. Designed for Claude Code, Codex, Cursor, Grok Build, GitHub Copilot CLI, OpenCode, and any harness that reads the Agent Skills `SKILL.md` format. MIT licensed.
+> **Status:** v0.11.0. Designed for Claude Code, Codex, Cursor, Grok Build, GitHub Copilot CLI, OpenCode, and any harness that reads the Agent Skills `SKILL.md` format. MIT licensed.
 
 ## What's inside
 
@@ -11,8 +11,8 @@ The skill lives under [`skills/go-ultimate/`](skills/go-ultimate/) and is struct
 | Path | Purpose |
 |---|---|
 | `skills/go-ultimate/SKILL.md` | The skill itself — when it applies, the non-negotiable principles, the project-type decision tree, conflict precedence. |
-| `skills/go-ultimate/references/` | Deep dives loaded on demand: `architecture.md`, `engineering-policy.md`, `modern-go.md`, `testing.md`, `code-review.md`, `libraries.md`, `project-layouts.md`, `wiring-and-runtime.md`, `modular-monolith.md`, `mcp-server.md`, `agents.md`. |
-| `skills/go-ultimate/assets/` | Scaffolded project templates per type: `cli-simple`, `cli-cobra`, `library`, `game`, `mcp-server`, `webservice` (all `build`, `vet` and `test -race` green). |
+| `skills/go-ultimate/references/` | Deep dives loaded on demand: `architecture.md`, `engineering-policy.md`, `modern-go.md`, `testing.md`, `code-review.md`, `libraries.md`, `project-layouts.md`, `wiring-and-runtime.md`, `modular-monolith.md`, `production-readiness.md`, `repo-and-ci.md`, `mcp-server.md`, `agents.md`. |
+| `skills/go-ultimate/assets/` | Scaffolded project templates per type: `cli-simple`, `cli-cobra`, `library`, `game`, `mcp-server`, `webservice` (all `build`, `vet` and `test -race` green), plus `ci/` workflows. |
 | `skills/go-ultimate/scripts/` | `goversion/main.go` (detects the project's `go.mod` version) and `check-source-versions.sh` + `source-versions.json` (drift checker for upstream donor sources). |
 | `skills/go-ultimate/evals/` | Example prompts and expected behaviors for catching skill drift. |
 
@@ -92,19 +92,25 @@ When triggered, the skill:
 1. Detects the project's Go version (`go run <skill-dir>/scripts/goversion/main.go <project>`) and gates feature usage on it.
 2. Routes the project through a decision tree — script / CLI / library / backend service / MCP server / AI agent — and loads the matching reference.
 3. Applies nine non-negotiable principles (modern version-gated Go, no `pkg/`, context-first, thin adapters, concurrency hygiene, etc.).
-4. Resolves conflicts via an explicit precedence ladder (architecture → modern-go → engineering-policy → libraries → code-review → mcp-server → agents).
+4. Resolves conflicts via an explicit precedence ladder (architecture → modern-go → engineering-policy → libraries → code-review → mcp-server → agents → production-readiness → repo-and-ci).
 
 See the [`SKILL.md`](skills/go-ultimate/SKILL.md) for the full opinionated rule set.
 
 ## Donor sources
 
-The skill synthesizes eight upstream sources. Full attribution and the live pins used to detect upstream drift are in [`skills/go-ultimate/scripts/source-versions.json`](skills/go-ultimate/scripts/source-versions.json). Summary:
+The skill synthesizes thirteen upstream sources. Full attribution and the live pins used to detect upstream drift are in [`skills/go-ultimate/scripts/source-versions.json`](skills/go-ultimate/scripts/source-versions.json). Summary:
 
 **General Go:** `teetsh-org/claude-skills#golang-code-review`, `JetBrains/go-modern-guidelines#use-modern-go`, `powerman/skills#go-bounded-context-hexagonal` (v0.6.0), `powerman/skills#go-engineering-policy` (v0.0.5).
+
+**Style guides:** [`google/styleguide#go`](https://google.github.io/styleguide/go/) (CC-BY-3.0), [`uber-go/guide`](https://github.com/uber-go/guide) (Apache-2.0).
+
+**Repository / production practice:** `metalagman/agent-skills#go-senior-developer`, `#go-oss-maintainer`, `#golangci-lint-strict`.
 
 **Agent / MCP:** `cloudwego/eino#orchestration-design-principles`, `cloudwego/eino#adk-0.1`, `modelcontextprotocol/go-sdk` (v1.6.1), `philschmid.de#mcp-best-practices`, `modelcontextprotocol.info#docs/best-practices`.
 
 > Originally also sourced from `danicat/skills#go-best-practices` and `danicat/skills#go-project-setup`; both were deleted upstream on 2026-07-21. Their distilled content is now owned and maintained by this skill (project-setup boilerplates under `assets/`, best-practices material folded into `references/engineering-policy.md` and `references/code-review.md`).
+
+> `metalagman/agent-skills` ships no LICENSE file, so its text is all-rights-reserved by default. Nothing is copied from it verbatim — the rules were extracted and rewritten, with the donor credited in each affected reference. Its bulk style-guide documents are derivatives of the Google and Uber guides, which this skill pins and attributes directly from upstream instead. Its tool-specific playbooks (`go-fx`, `go-goose`, `go-options-gen`, `go-adk`) are deliberately **not** folded in: they are version-fragile, they contradict this skill's defaults (hand-written wiring over Fx, Resolvable Config Struct over options-gen), and an always-on skill should not carry per-library tutorials.
 
 ### Checking for upstream drift
 

--- a/skills/go-ultimate/SKILL.md
+++ b/skills/go-ultimate/SKILL.md
@@ -13,7 +13,7 @@ license: MIT
 compatibility: Designed for Claude Code, Codex, Cursor, Grok Build, GitHub Copilot CLI, OpenCode, and any harness that reads the Agent Skills SKILL.md format. Targets any Go project.
 metadata:
   author: Djarvur
-  version: '0.10.0'
+  version: '0.11.0'
   maintainers:
     - name: Daniel Podolsky
       url: https://github.com/onokonem
@@ -29,6 +29,11 @@ metadata:
     - modelcontextprotocol/go-sdk#design
     - philschmid.de#mcp-best-practices
     - modelcontextprotocol.info#docs/best-practices
+    - google/styleguide#go
+    - uber-go/guide
+    - metalagman/agent-skills#go-senior-developer
+    - metalagman/agent-skills#go-oss-maintainer
+    - metalagman/agent-skills#golangci-lint-strict
   source-notes:
     danicat-skills-deleted: |
       Originally also sourced from danicat/skills#go-best-practices and
@@ -41,14 +46,23 @@ metadata:
     cloudwego-eino-adk-0.1: |
       `adk-0.1` is an in-repo ADK package, not a versioned tag; treated as a
       point-in-time reference, not a recoverable pin.
+    metalagman-unlicensed: |
+      metalagman/agent-skills ships no LICENSE file, so its text is
+      all-rights-reserved by default. Nothing is copied from it verbatim: the
+      rules were extracted and rewritten in this skill's own voice, and the
+      donor is credited in the affected references. Its bulk style-guide
+      documents are derivatives of Google styleguide (CC-BY-3.0) and uber-go/
+      guide (Apache-2.0), which this skill sources directly from upstream
+      instead.
 ---
 
 # Go Ultimate Skill
 
 A single, opinionated skill for writing the best Go programs — synthesized from
-four general-Go skills plus four agent/MCP donors (one donor, eino, contributes
-two documents). Opinions represent the synthesized consensus; where the donors
-disagreed, this skill resolved the conflict per the precedence ladder below.
+four general-Go skills, four agent/MCP donors (one donor, eino, contributes two
+documents), the Google and Uber style guides, and a repository/production-practice
+donor. Opinions represent the synthesized consensus; where the donors disagreed,
+this skill resolved the conflict per the precedence ladder below.
 
 ## When this skill applies
 
@@ -127,6 +141,7 @@ Is the code meant to be imported by other modules?
 Is the code a long-running server (HTTP/gRPC/messaging)?
 ├── Yes → BACKEND SERVICE
 │          → references/architecture.md        (mandatory)
+│          → references/production-readiness.md (mandatory)
 │          → references/project-layouts.md § Service
 │          → references/engineering-policy.md
 │
@@ -134,12 +149,14 @@ Is the code a server exposing tools/resources/prompts to LLMs over MCP?
 ├── Yes → MCP SERVER
 │          → references/mcp-server.md          (mandatory)
 │          → references/project-layouts.md § Service or § CLI (stdio server = CLI-shaped)
+│          → references/production-readiness.md (if hosted/long-running, not stdio)
 │          → references/engineering-policy.md
 │
 Is the code an LLM-driven agent that calls tools / orchestrates multi-step reasoning?
 ├── Yes → AI AGENT
 │          → references/agents.md              (mandatory)
 │          → references/project-layouts.md § CLI or § Service (depends on hosting)
+│          → references/production-readiness.md (if hosted/long-running)
 │          → references/engineering-policy.md
 │
 Is the code a code generator, linter, or analysis tool?
@@ -148,6 +165,11 @@ Is the code a code generator, linter, or analysis tool?
 │
 Otherwise → ask the user to clarify before proposing structure.
 ```
+
+**Regardless of type:** when initializing a repository, adding CI, or reviewing
+repository hygiene, also load
+[references/repo-and-ci.md](references/repo-and-ci.md) — required files, ignore
+baselines, `go tool` pinning, workflow shape, release stamping.
 
 ---
 
@@ -207,6 +229,12 @@ These are the consensus backbone. Every Go file this skill touches obeys them.
 | Libraries: README (rationale + honest comparison + payoff-first quick start) vs `doc.go` (contracts) | [libraries.md](references/libraries.md) |
 | `go.mod`: apps latest, libraries latest-1 | [engineering-policy.md](references/engineering-policy.md) |
 | Lint: `golangci-lint` + `govet` + `go test -race` mandatory in CI | [engineering-policy.md](references/engineering-policy.md) |
+| Naming: `MixedCaps`, initialism case (`userID`, `HTTPClient`), no `Get` prefix, no `util`/`common` package | [engineering-policy.md](references/engineering-policy.md) |
+| `%w` only when the cause is intended as API; `%v` for a dependency's error crossing a public boundary | [engineering-policy.md](references/engineering-policy.md) |
+| No mutable globals; no goroutines or I/O in `init()`; comma-ok on every type assertion | [engineering-policy.md](references/engineering-policy.md) |
+| Fan-out is bounded (`SetLimit`/semaphore); channels unbuffered or size 1 | [engineering-policy.md](references/engineering-policy.md) |
+| Repo must have `LICENSE`, `README.md`, `AGENTS.md`, ignore files, `.golangci.yml`, CI; tools pinned via `go tool` | [repo-and-ci.md](references/repo-and-ci.md) |
+| Services: bounded calls, safe retries, stable error contract, liveness≠readiness, outbox, rolling-safe migrations | [production-readiness.md](references/production-readiness.md) |
 | MCP server: official `go-sdk`, typed tool handlers, two-channel errors, tool design as outcomes-not-operations | [mcp-server.md](references/mcp-server.md) |
 | AI agent: ReAct loop w/ bounded iterations, 6 topology archetypes, type-aligned composition (reject `map[string]any` between nodes) | [agents.md](references/agents.md) |
 
@@ -229,6 +257,17 @@ When two references seem to disagree:
    pagination, middleware) → [mcp-server.md](references/mcp-server.md) wins.
 7. **AI agents in Go** (ReAct loop, multi-agent topology, typed data flow
    between nodes, state externalism) → [agents.md](references/agents.md) wins.
+8. **Runtime behavior of a long-running service** (timeout/retry/idempotency
+   policy, API error contract, liveness vs readiness, metric cardinality,
+   migration safety, outbox) →
+   [production-readiness.md](references/production-readiness.md) wins. It
+   refines rule 3: engineering-policy sets the observability *floor*, this sets
+   the service shape.
+9. **Concrete repository and pipeline files** (required files, ignore baselines,
+   workflow YAML, `go tool` pinning, build stamping) →
+   [repo-and-ci.md](references/repo-and-ci.md) wins. It also refines rule 3:
+   engineering-policy states which gates are mandatory, this states how they are
+   written.
 
 The adapter carve-out ([mcp-server.md](references/mcp-server.md) § "Adapter
 carve-out") refines rule 5 of the non-negotiable principles for MCP handlers

--- a/skills/go-ultimate/SKILL.md
+++ b/skills/go-ultimate/SKILL.md
@@ -43,6 +43,14 @@ metadata:
       project-setup boilerplates live under assets/ (verified to build with
       Go 1.26.x) and the best-practices material is folded into
       references/engineering-policy.md and references/code-review.md.
+    jetbrains-restructured: |
+      JetBrains/go-modern-guidelines restructured on 2026-08-11: the skill moved
+      path and was rewritten from a static per-version markdown catalog into a
+      thin wrapper around a Modern Go Guidelines CLI. The catalog no longer
+      exists upstream as readable markdown, so references/modern-go.md now owns
+      it (same as the danicat material) and new Go releases are folded in by
+      hand. The CLI approach is deliberately not adopted — it would add a runtime
+      dependency on a third-party binary to an otherwise self-contained skill.
     cloudwego-eino-adk-0.1: |
       `adk-0.1` is an in-repo ADK package, not a versioned tag; treated as a
       point-in-time reference, not a recoverable pin.

--- a/skills/go-ultimate/assets/README.md
+++ b/skills/go-ultimate/assets/README.md
@@ -4,6 +4,9 @@ Copy-paste starting points, one per project type from the
 [decision tree in SKILL.md](../SKILL.md#project-type-decision-tree). Each template
 is a minimal, runnable skeleton matching the layout the skill mandates.
 
+Plus [`ci/`](ci/) — GitHub Actions workflows that apply to any project type,
+independent of the template you start from.
+
 ## How to use
 
 1. Pick the template that matches the project type:
@@ -14,6 +17,8 @@ is a minimal, runnable skeleton matching the layout the skill mandates.
    - [`mcp-server/`](mcp-server/) — MCP server over stdio (typed handlers).
    - [`game/`](game/) — Ebitengine game.
 2. Copy the directory to your new project: `cp -R cli-simple /path/to/my-tool`.
+   Then copy the CI workflows into `.github/workflows/`:
+   `cp ci/test.yml ci/lint.yml /path/to/my-tool/.github/workflows/`.
 3. Find-and-replace the module path `example.com/<name>` with your real module
    (`go mod edit -module github.com/you/my-tool`).
 4. Replace the placeholder name in `main.go` / the package name as appropriate.
@@ -35,6 +40,26 @@ is a minimal, runnable skeleton matching the layout the skill mandates.
 
    Only then report success to the user, with the final tree and the green
    command output.
+
+## CI workflows
+
+[`ci/test.yml`](ci/test.yml) and [`ci/lint.yml`](ci/lint.yml) drop into
+`.github/workflows/` unchanged and implement the gates
+[engineering-policy.md § Dependencies and CI](../references/engineering-policy.md)
+makes mandatory: `build`, `vet`, `test -race -cover`, module tidiness,
+`govulncheck`, `golangci-lint`, `gofmt`.
+
+Two things they do on purpose, explained in
+[repo-and-ci.md](../references/repo-and-ci.md):
+
+- **`go-version-file: go.mod`** — the Go version lives in one place, so CI can
+  never test a different language version than the code declares.
+- **A pinned `golangci-lint` version** — the linter changes what it reports
+  between minor versions; unpinned, it turns unrelated PRs red.
+
+`test.yml` carries a commented-out `compat` matrix job: uncomment it for
+libraries, which must test their whole supported version range, and delete it for
+applications, which ship one version.
 
 ## Rules baked in
 

--- a/skills/go-ultimate/assets/ci/lint.yml
+++ b/skills/go-ultimate/assets/ci/lint.yml
@@ -1,0 +1,48 @@
+# golangci-lint workflow — copy to .github/workflows/lint.yml
+#
+# The linter version is pinned on purpose: golangci-lint changes what it reports
+# between minor versions, and an unpinned linter turns unrelated PRs red.
+# Bump it deliberately, as its own commit. See references/repo-and-ci.md.
+name: Lint
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: lint-${{ github.event_name }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  golangci-lint:
+    name: golangci-lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+
+      # golangci-lint-action v7+ is required for v2 version strings. The linter
+      # must be built with a Go version >= the module's `go` directive, or it
+      # refuses to run ("language version used to build golangci-lint is lower
+      # than the targeted Go version").
+      - uses: golangci/golangci-lint-action@v7
+        with:
+          version: v2.12
+
+      # gofmt is not part of the golangci-lint v2 default set; assert it here so
+      # formatting never reaches review.
+      - name: gofmt
+        run: |
+          bad=$(gofmt -l .)
+          if [ -n "$bad" ]; then
+            echo "::error::gofmt would reformat:"
+            echo "$bad"
+            exit 1
+          fi

--- a/skills/go-ultimate/assets/ci/test.yml
+++ b/skills/go-ultimate/assets/ci/test.yml
@@ -1,0 +1,74 @@
+# Go test workflow — copy to .github/workflows/test.yml
+#
+# Gates every push and PR on the skill's mandatory checks:
+#   build, vet, test -race -cover, module tidiness, govulncheck.
+#
+# The Go version comes from go.mod (go-version-file) so it lives in exactly one
+# place. See references/repo-and-ci.md.
+name: Test
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+  workflow_dispatch:
+
+# The default token is over-privileged; grant only what these jobs need.
+permissions:
+  contents: read
+
+concurrency:
+  # Include the event name so a push and a pull_request for the same ref do not
+  # cancel each other.
+  group: test-${{ github.event_name }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  test:
+    name: test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+
+      - run: go build ./...
+      - run: go vet ./...
+      - run: go test -race -cover ./...
+
+      # Fail if go.mod/go.sum are not tidy. On Go 1.23+ `go mod tidy -diff`
+      # does this without mutating the working tree.
+      - name: modules are tidy
+        run: |
+          go mod tidy
+          git diff --exit-code -- go.mod go.sum
+
+  vuln:
+    name: govulncheck
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+      # Reports only vulnerabilities reachable from this module's call graph,
+      # so it is low-noise enough to gate on.
+      - run: go run golang.org/x/vuln/cmd/govulncheck@latest ./...
+
+  # Libraries only: test the whole supported version range, not just the floor.
+  # Delete this job for applications, which ship one version.
+  #
+  # compat:
+  #   name: go ${{ matrix.go }}
+  #   runs-on: ubuntu-latest
+  #   strategy:
+  #     fail-fast: false
+  #     matrix:
+  #       go: ['1.25', '1.26']
+  #   steps:
+  #     - uses: actions/checkout@v4
+  #     - uses: actions/setup-go@v5
+  #       with:
+  #         go-version: ${{ matrix.go }}
+  #     - run: go test -race ./...

--- a/skills/go-ultimate/evals/README.md
+++ b/skills/go-ultimate/evals/README.md
@@ -159,9 +159,74 @@ func NewServer(opts ...Option) *Server { ... }
 
 ---
 
+## Eval 6 — production readiness (production-readiness trigger)
+
+**Setup:** a Go service with an outbound adapter that calls a payment API and
+publishes an event after committing to the database.
+
+**Prompt:**
+> "Make this order service production-ready before we launch."
+
+**Expected behavior:**
+- Skill activates and routes to BACKEND SERVICE → loads `production-readiness.md`.
+- Agent flags, at minimum:
+  - **Retry safety** — the payment call is not idempotent, so it needs an
+    idempotency key before any retry is added; backoff must have jitter, a cap,
+    and honor `ctx.Done()`.
+  - **The dual-write bug** — "commit, then publish" loses events. Agent proposes
+    the **outbox** pattern (event written in the same transaction, relayed
+    after), and names at-least-once delivery as the consequence.
+  - **Deadlines** — each outbound call derives its own timeout rather than
+    inheriting the whole request budget.
+  - **Error contract** — internal errors are not returned to the client; domain
+    errors map to transport codes *in the adapter*, with a stable `code` and a
+    `request_id`.
+  - **Liveness vs readiness** — `/healthz` must not check the database;
+    `/readyz` must, and must fail first on shutdown.
+- Agent does **not** propose a specific APM vendor or framework — the reference
+  is vendor-neutral.
+
+**Failure signals:**
+- Agent adds a retry loop around the payment call without raising idempotency.
+- Agent accepts "commit then publish" and only suggests logging the publish
+  failure.
+- Agent puts the domain→HTTP error mapping inside `internal/app`.
+- Agent proposes a liveness probe that pings dependencies.
+
+---
+
+## Eval 7 — repository hygiene (repo-and-ci trigger)
+
+**Setup:** a Go repo with `go.mod`, source, and nothing else — no LICENSE, no CI,
+no `.golangci.yml`.
+
+**Prompt:**
+> "Set this repo up properly before I open-source it."
+
+**Expected behavior:**
+- Skill activates and loads `repo-and-ci.md`.
+- Agent adds the required-file set: `LICENSE` (MIT default), `README.md`,
+  `AGENTS.md`, `.gitignore`, `.dockerignore`, `.golangci.yml`, and workflows
+  under `.github/workflows/`.
+- Workflows use **`go-version-file: go.mod`**, not a hardcoded Go version, and
+  pin the `golangci-lint` version.
+- Agent pins tools with `go get -tool` + `go tool <name>`, not `go install` and
+  not a `tools.go` blank-import file.
+- If a file already exists (e.g. `.gitignore`), agent **merges** the missing
+  baseline patterns instead of overwriting, and says so.
+- Agent may copy [`assets/ci/`](../assets/ci/) directly.
+
+**Failure signals:**
+- Hardcoded `go-version: '1.xx'` in the workflow.
+- `tools.go` with blank imports.
+- An existing `.gitignore` or `.golangci.yml` silently replaced.
+- Agent declares the repo ready with no LICENSE.
+
+---
+
 ## Negative evals — where the skill must NOT activate
 
-The five evals above check **under-triggering** (skill should fire but doesn't).
+The seven evals above check **under-triggering** (skill should fire but doesn't).
 These check **over-triggering**: prompts that look superficially Go-adjacent
 but where this skill has nothing to contribute. The skill must stay dormant —
 no `go run <skill-dir>/scripts/goversion/`, no "as a Go skill I recommend…",

--- a/skills/go-ultimate/references/code-review.md
+++ b/skills/go-ultimate/references/code-review.md
@@ -60,6 +60,16 @@ architecture evaluation, test-quality checks, or auditing existing code.
 - Small, single-method interfaces preferred.
 - `defer` for resource cleanup.
 - Comments explain *why*, not *what*.
+- **Comma-ok on every type assertion** — a bare `x.(T)` is a panic on unexpected
+  input.
+- **Composite literals name their fields**; positional literals break silently
+  when a field is added upstream.
+- **Slices/maps copied at API boundaries** when stored or returned, or the
+  aliasing is documented.
+- **No mutable package-level state**, and no goroutines or I/O in `init()`.
+- Naming: `MixedCaps`, consistent initialism case (`userID`, `HTTPClient`), no
+  `Get` prefix on accessors, no `util`/`common`/`helpers` package.
+- Struct tags present on anything marshaled.
 
 ### Errors
 - Wrapped at each layer boundary: `fmt.Errorf("doing X: %w", err)`.
@@ -67,6 +77,13 @@ architecture evaluation, test-quality checks, or auditing existing code.
 - `errors.Join` for aggregations (Go 1.20+).
 - No `==` for error comparison.
 - No log-and-return-the-same-error.
+- **`%w` only where the cause is intended as API** — `%v` for a dependency's
+  error crossing a public boundary (see
+  [engineering-policy.md § `%w` vs `%v`](engineering-policy.md)).
+- `error` is the last return; exported functions return the `error` interface,
+  not a concrete type.
+- `os.Exit` / `log.Fatal*` appear only in `main()`.
+- No `failed to` prefixes stacking up through the wrap chain.
 
 ### Concurrency
 - Every goroutine has an exit condition (Context/WaitGroup/done channel).
@@ -78,6 +95,11 @@ architecture evaluation, test-quality checks, or auditing existing code.
 - No goroutine leaks: cancellation propagates, wait groups decrement.
 - No shared mutable state without synchronization; no copied mutexes (`go vet`).
 - `t.Parallel()` in tests to surface hidden shared state.
+- **Fan-out is bounded** — `errgroup.SetLimit`, a worker pool or a semaphore.
+  Ranging over a request-sized slice with `g.Go` is unbounded concurrency.
+- **Channels unbuffered or size 1**; a larger buffer needs a stated reason.
+- Mutex declared as a value field, not embedded, with a comment naming what it
+  guards. Atomics only for a single independent value.
 
 ### Security (when relevant: auth, payments, user input, external APIs)
 - Input validation and sanitization at the boundary.
@@ -125,6 +147,35 @@ architecture evaluation, test-quality checks, or auditing existing code.
 - `internal/` used aggressively for private code.
 - `cmd/<name>/` for multiple binaries; `main.go` at root for single binary.
 - `main()` contains no testable logic — `run(ctx, cfg) error` pattern for CLIs.
+- Required repo files present: `LICENSE`, `README.md`, `AGENTS.md`,
+  `.gitignore`, `.golangci.yml`, CI workflows. See
+  [repo-and-ci.md](repo-and-ci.md).
+- Tools invoked via `go tool` with the `tool` directive in `go.mod`, not
+  `go install` or `tools.go`.
+- CI pins the Go version with `go-version-file: go.mod`, not a hardcoded string.
+
+### Production readiness (long-running services)
+
+Apply when reviewing a service, a hosted MCP server, or an agent runtime. Full
+detail in [production-readiness.md](production-readiness.md).
+
+- **Every outbound call has a context deadline**, not just a client timeout.
+- **Retries are on idempotent operations only**, with exponential backoff +
+  jitter, a cap, and `ctx.Done()` honored. Retries are not stacked at multiple
+  layers.
+- **No raw internal error returned to a client**; domain→transport mapping lives
+  in the adapter, and responses carry a stable `code` plus a `request_id`.
+- **Liveness does not check dependencies**; readiness does, and fails first on
+  shutdown.
+- **Metric and span labels are bounded** — no user id, request id or raw path.
+- **Config is read once at startup**, not via `os.Getenv` deep in the call stack;
+  invalid config fails the process rather than the first request.
+- **Secrets cannot be logged** — redacting `LogValue()`/`String()` on
+  credential-bearing types.
+- **Migrations are rolling-deploy safe** (no rename/drop in the same deploy as
+  the code change).
+- **"DB write + publish event" uses an outbox**, not a best-effort publish after
+  commit.
 
 ---
 
@@ -253,7 +304,11 @@ judgment) `Important`.
 - Review structure (Critical/Important/Suggestion/Positive + What-Why-How) from
   [teetsh-org `golang-code-review`](https://github.com/teetsh-org/claude-skills).
 - Senior review checklist items from [danicat `go-best-practices`](https://github.com/danicat/skills).
-- Review areas aligned with the rules in [engineering-policy.md](engineering-policy.md)
-  and [architecture.md](architecture.md).
+- Review areas aligned with the rules in [engineering-policy.md](engineering-policy.md),
+  [architecture.md](architecture.md), [repo-and-ci.md](repo-and-ci.md) and
+  [production-readiness.md](production-readiness.md).
+- Idiomatic/error/concurrency items added from the [Google](https://google.github.io/styleguide/go/)
+  (CC-BY-3.0) and [Uber](https://github.com/uber-go/guide) (Apache-2.0) style guides;
+  production-readiness items distilled from [metalagman `go-senior-developer`](https://github.com/metalagman/agent-skills).
 - All Teetsh-specific patterns (`school_id`, `pkg/externals/tracker/client.go`,
   `domain/repo/service/handler`, multi-tenancy conventions) deliberately removed.

--- a/skills/go-ultimate/references/engineering-policy.md
+++ b/skills/go-ultimate/references/engineering-policy.md
@@ -9,6 +9,7 @@ style/lint guidance for non-architectural Go conventions.
 - [`go.mod` version policy](#gomod-version-policy)
 - [`package main`](#package-main)
 - [Variable scope policy](#variable-scope-policy)
+- [Globals and `init()`](#globals-and-init)
 - [Style and idioms](#style-and-idioms)
 - [`context.Context` — do not alias by default](#contextcontext-do-not-alias-by-default)
 - [Errors — taxonomy and rules](#errors-taxonomy-and-rules)
@@ -87,11 +88,147 @@ if ok {
 
 ---
 
+## Globals and `init()`
+
+### No mutable globals
+
+A mutable package-level variable is a hidden input to every function that reads
+it: it defeats parallel tests, creates ordering dependencies between packages,
+and makes a function's behavior unreproducible from its arguments.
+
+- **Pass dependencies explicitly** — constructor injection into a struct, not a
+  package-level `var`. This is the same rule that makes `wire.go` possible.
+- **Mutable global function pointers are the worst case** ("swap `timeNow` in the
+  test"). Inject a clock or an interface instead; a test that mutates a global
+  cannot be `t.Parallel()`.
+- Package-level `var` is fine when it is **effectively immutable** after
+  initialization: sentinel errors, compiled regexps, lookup tables. Nothing
+  writes to them after `init`.
+
+### `init()` is a last resort
+
+- **Never start a goroutine in `init()`.** There is no way to stop it, no way to
+  observe its failure, and it starts before `main` has decided whether the
+  process should do anything. Background work belongs to an object with an
+  explicit lifecycle, started from wiring.
+- **`init()` must not do I/O**, read the environment, or mutate global/process
+  state. Any of these makes importing the package a side effect, which breaks
+  tests and makes failure unreportable — `init()` cannot return an error.
+- **`init()` must not depend on ordering** between files or packages. Ordering
+  is defined but not obvious, and the next refactor changes it silently.
+- Legitimate uses are narrow: registering a driver or codec with a registry, and
+  computing a derived constant that cannot be a composite literal. Everything
+  else belongs in a constructor.
+
+---
+
 ## Style and idioms
 
 These are the small-surface rules that keep a codebase consistent and
 Go-idiomatic. Most are derivable from [Go Code Review Comments](https://go.dev/wiki/CodeReviewComments)
 and the [Google Go Style Guide](https://google.github.io/styleguide/go/).
+
+### Least mechanism
+
+**Prefer the simplest construct that does the job.** In descending order of
+preference: a core language construct (slice, map, channel, plain function) → the
+standard library → a well-established third-party dependency → new machinery of
+your own.
+
+This is the principle behind several rules that otherwise look unrelated —
+vanilla `testing` over an assertion library, a `Config` struct over functional
+options, hand-written wiring before a DI framework, `log/slog` over a logging
+abstraction layer. Sophisticated machinery has to earn its place against the
+boring version; the boring version does not have to justify itself.
+
+### Declarations
+
+- **`:=` for initialization with a real value**; `var` for zero-value
+  initialization.
+
+  ```go
+  var buf bytes.Buffer     // zero value is useful
+  var users []User         // nil slice, ready to append
+  count := len(items)      // real value
+  ```
+
+- **Nil slices, not empty slices.** `var s []T` over `s := []T{}`. A nil slice
+  appends, ranges, and reports `len` identically; the difference only shows up in
+  JSON encoding, and an API whose behavior depends on nil-vs-empty is a bug
+  waiting to be reported. Test emptiness with `len(s) == 0`, never `s == nil`.
+- **Composite literals name their fields**: `User{Name: n, Email: e}`, not
+  `User{n, e}`. Positional literals break silently when a field is inserted
+  upstream. (The one tolerable exception is a test table with two or three
+  obvious columns.)
+- **Do not shadow predeclared identifiers** — no variable named `error`, `string`,
+  `len`, `new`, `max`, `min`, `copy`. The code still compiles, which is what makes
+  it dangerous.
+
+### Type assertions
+
+**Always use the comma-ok form.** A bare `v := x.(T)` panics on a type it did not
+expect, and the input that triggers it is usually external.
+
+```go
+// GOOD
+v, ok := x.(T)
+if !ok {
+    return fmt.Errorf("expected %T, got %T", T{}, x)
+}
+
+// BAD — panics on unexpected input.
+v := x.(T)
+```
+
+The exception is a type switch, where the failure case is already an explicit
+branch.
+
+### Slices and maps at API boundaries
+
+Slices and maps are references. Storing or returning one without copying hands
+the other side a live handle to your internal state.
+
+- **Copy on the way in** when you retain the argument beyond the call.
+- **Copy on the way out** when returning something a caller must not mutate.
+
+```go
+func NewPolicy(rules []Rule) *Policy {
+    p := &Policy{rules: slices.Clone(rules)} // caller may reuse its slice
+    return p
+}
+
+func (p *Policy) Rules() []Rule {
+    return slices.Clone(p.rules) // caller cannot corrupt p
+}
+```
+
+If copying is too expensive to be reasonable, document the aliasing explicitly —
+an undocumented shared slice is a data race that only shows up under load.
+
+### Struct tags and format strings
+
+- **Every struct that is marshaled carries field tags** (`json`, `yaml`, `db`).
+  Without them the wire format is derived from Go identifier names, so a rename
+  silently changes the payload.
+- **Declare format strings as constants** when reused, and end custom
+  `Printf`-style functions with `f` (`logf`, `wrapf`) — that suffix is what lets
+  `go vet` check the arguments. A `Printf`-style function not ending in `f` is
+  invisible to the vet analyzer.
+
+### Signal boosting
+
+When code deliberately departs from the idiom a reader expects, **say so in a
+comment**. The canonical case is checking `err == nil` to take the happy path:
+
+```go
+// Only proceed when the lookup succeeded; a miss is expected here and not an error.
+if err == nil {
+    return cached, nil
+}
+```
+
+Without the comment, the next reader assumes it is a typo for `err != nil` and
+"fixes" it.
 
 ### Error strings
 - Lowercase, no trailing punctuation: `fmt.Errorf("something failed")`, not
@@ -99,6 +236,10 @@ and the [Google Go Style Guide](https://google.github.io/styleguide/go/).
   chain reads as a sentence.)
 - **No in-band errors.** Return `(value, ok)` or `(value, error)`, never a
   sentinel like `-1` or `nil` to signal failure on a value-returning function.
+- **No `failed to` / `error while` prefixes.** Every layer adds one and the
+  result reads `failed to save user: failed to exec query: failed to dial`. The
+  value is already an error; say what was being attempted:
+  `fmt.Errorf("save user %d: %w", id, err)`.
 
 ### Control flow
 - **Handle errors first, return early.** No `else` after an error return.
@@ -184,9 +325,47 @@ mix. Do not introduce a `Ctx` alias in a project that does not already use one.
 - **Never** compare errors with `==`. Use `errors.Is(err, target)` (handles wrapping).
 - Use `errors.As(err, &target)` for typed errors (or `errors.AsType[T]` on Go 1.26+).
 
+### Signature rules
+- **`error` is the last return value**, always.
+- **Exported functions return the `error` interface**, never a concrete error
+  type. Returning `*MyError` makes every caller's `err != nil` check wrong for
+  the typed-nil reason below, and it pins the concrete type into your public API.
+- **`os.Exit` and `log.Fatal*` only in `main()`**, and preferably once. They skip
+  every `defer`, so anywhere else they abandon open files, unflushed buffers and
+  in-flight work. Library and business code returns errors.
+- **`Must*` names a helper that panics on failure** (`template.Must`,
+  `regexp.MustCompile`). The prefix is the whole warning label — use it only for
+  package-level initialization of values that are compile-time constant in
+  practice, never for anything that depends on runtime input.
+
 ### Wrapping
 - Wrap with `fmt.Errorf("doing X: %w", err)` at each layer boundary.
 - Wrap once per layer; do not re-wrap an already-wrapped error in the same layer.
+
+### `%w` vs `%v` — wrapping is an API decision
+
+`%w` makes the wrapped error **part of your package's contract**: callers can
+match it with `errors.Is`/`errors.As`, so it can no longer be swapped out without
+a breaking change. `%v` flattens it to text and keeps it an implementation
+detail.
+
+| Use | When |
+|---|---|
+| `%w` | Callers legitimately need to react to the cause — a sentinel they must handle (`ErrNotFound`), or a typed error they extract fields from. |
+| `%v` | The cause is an implementation detail: a third-party driver's error, anything at a system boundary where the underlying library is replaceable. |
+
+```go
+// %w — ErrNotFound is documented API; the caller is expected to branch on it.
+return fmt.Errorf("load user %d: %w", id, ErrNotFound)
+
+// %v — the caller must not couple to pgx's error types.
+return fmt.Errorf("load user %d: %v", id, pgErr)
+```
+
+Default to `%w` **within** a bounded context, where you own both sides. Prefer
+`%v` when re-exporting a dependency's failure across your public boundary, unless
+you are deliberately promoting it to contract. Place `%w` last in the format
+string so the chain reads as nested context.
 
 ### Sentinel errors
 - Define package-level sentinels with `errors.New` for expected error conditions
@@ -291,6 +470,58 @@ if err := g.Wait(); err != nil { ... }
 > goroutine and tracks it in one call — use it directly when you do not need
 > errgroup's cancel-on-first-error behavior. Use `errgroup` when you do.
 
+- **Never start a goroutine in `init()`** — see
+  [§ Globals and `init()`](#globals-and-init).
+
+### Bounded concurrency
+
+**Fan-out over a slice of unknown length is unbounded concurrency.** One request
+with 100k items becomes 100k goroutines, 100k open connections, and an
+out-of-memory kill.
+
+```go
+g, ctx := errgroup.WithContext(ctx)
+g.SetLimit(runtime.GOMAXPROCS(0) * 4) // cap in flight; tune to the bottleneck
+for _, item := range items {
+    g.Go(func() error { return process(ctx, item) })
+}
+```
+
+Use `errgroup.SetLimit`, a worker pool, or `golang.org/x/sync/semaphore`. The
+limit belongs to whatever is actually scarce — upstream connections, database
+pool size, CPU — not to a round number.
+
+### Channel sizing
+
+**Channels are unbuffered, or buffered with size 1.** Any other size needs a
+written justification.
+
+An unbuffered channel makes backpressure explicit: the sender blocks when the
+receiver is behind, which is information. A large buffer hides that signal, turns
+a queue-depth problem into a latency problem you cannot see, and loses everything
+in flight when the process dies. Size 1 is the useful special case: a
+non-blocking handoff, or a signal channel a sender must never block on.
+
+If a buffer size is a tuning parameter, it is a queue — make it one explicitly,
+with a depth metric ([production-readiness.md](production-readiness.md)).
+
+### Mutexes and atomics
+
+- **The zero value of `sync.Mutex` is ready to use.** Declare it as a value field
+  (`mu sync.Mutex`), never a pointer, and never call `new(sync.Mutex)`.
+- **Do not embed a mutex** — not even unexported. Embedding promotes `Lock`/
+  `Unlock` into the struct's method set; if the struct is exported, callers can
+  lock your internal state, and if it is marshaled, the mutex becomes part of the
+  wire shape. Name the field.
+- Declare the mutex immediately above the fields it guards, and say what it
+  guards in a comment. A mutex whose scope is not written down gets it wrong on
+  the next edit.
+- **Atomics for a single independent value** (a counter, a flag) — `sync/atomic`'s
+  typed values (`atomic.Int64`, `atomic.Bool`, `atomic.Pointer[T]`) rather than
+  the loose functions. **A mutex for an invariant across several fields**: two
+  atomics updated in sequence are two separate observable states, which is
+  usually the bug.
+
 ---
 
 ## Constructor pattern — Resolvable Config Struct (not Functional Options)
@@ -361,10 +592,50 @@ APIs where the struct does not fit — rare. Default to the struct.
 
 ## Naming
 
+### Form
+
+- **`MixedCaps` / `mixedCaps`. No underscores.** Not in package names, type
+  names, function names, or variables. The exceptions are `_test.go` file-level
+  test function grouping, generated code, and low-level interop.
+- **Initialisms keep a consistent case**: `HTTPClient`, `userID`, `parseJSON`,
+  `ServeHTTP`, `xmlReader`. Never `HttpClient`, `userId`, `parseJson`. When an
+  initialism starts an unexported name it is all-lowercase: `urlPath`, not
+  `uRLPath`.
+- **Constants are `MixedCaps` too** — `MaxRetries`, not `MAX_RETRIES` or
+  `kMaxRetries`. Go has no separate constant naming convention.
+
+### Length and content
+
+- **Name length is proportional to scope.** `i`, `r`, `err` inside a five-line
+  loop; a descriptive name for a package-level value. A long name in a tiny scope
+  is noise; a short name in a large scope is a puzzle.
+- **Omit the type from the name** — `users`, not `userSlice`; `timeout`, not
+  `timeoutDuration`. The type is already in the signature.
+- **Do not repeat the package name in its identifiers.** From outside it reads
+  `user.User`, `http.HTTPServer`. Name it for how it will be called:
+  `user.Account`, `http.Server`.
+- **No `Get` prefix on accessors** — `u.Name()`, not `u.GetName()`. Reserve `Get`
+  for something that genuinely fetches (`GetUser(ctx, id)` hitting a store).
+  Verb-like names for actions, noun-like names for values.
+
+### Packages
+
 - Short, high-signal package names: `dom`, `app`, `dal`, `port`, `srv`, `svc`, `sub`, `repo`.
+- **Never `util`, `common`, `helpers`, `shared`, `base`, `misc`.** A package named
+  for its lack of a theme accumulates unrelated code forever and becomes an
+  import-cycle magnet. If a helper has no obvious home, that is a signal about the
+  design, not a reason to create `util`.
+- Lowercase, single word, no underscores, singular.
 - Do not repeat the directory noun in filenames — `order/app.go`, not `order/order.go`.
 - Generic filenames where the package gives context: `adapter.go`, `app.go`, `port.go`, `wire.go`.
+
+### Receivers and constructors
+
 - Use `New` as the constructor name when the package already explains what is built.
+- Receiver names are short and **identical across every method of a type** — if
+  one method uses `c`, none uses `client`.
+- **Receiver types are consistent too**: if any method needs a pointer receiver,
+  all of them take pointer receivers.
 - Exported identifiers have doc comments starting with the identifier name.
 
 ---
@@ -382,6 +653,10 @@ APIs where the struct does not fit — rare. Default to the struct.
 ---
 
 ## Dependencies and CI
+
+> The concrete shape — required repository files, ignore baselines, workflow
+> YAML, tool pinning, release stamping — is in
+> [repo-and-ci.md](repo-and-ci.md). This section is the policy it enforces.
 
 ### Linting (mandatory in CI)
 - **`go vet ./...`** — always.
@@ -490,6 +765,13 @@ defer stop()
 - **Tracing** — propagate `trace-id`/`request-id` through context; for inbound
   adapters, generate/extract it; for outbound, inject it. Defer full OTEL
   adoption to a project decision, but the context plumbing must exist from day one.
+- **Never log a secret.** Give credential-bearing types a redacting
+  `LogValue()`/`String()` so an accidental `slog.Any("cfg", cfg)` cannot leak
+  them.
+
+> This is the floor for any Go program. What a **service** additionally needs —
+> which metrics, label cardinality, health vs readiness, SLOs — is in
+> [production-readiness.md](production-readiness.md).
 
 ---
 
@@ -553,4 +835,7 @@ Store ADRs under `docs/adr/` (or `adr/`) numbered with a zero-padded prefix
 
 - [powerman `go-engineering-policy` v0.0.5](https://github.com/powerman/skills) — `go.mod`, `package main`, var-scope, Resolvable Config Struct, testing, `internal/` discipline.
 - [danicat `go-best-practices`](https://github.com/danicat/skills) — concurrency rule, the Style & Idioms section (error strings, early return, in-band errors, ctx-not-in-struct, receivers, value-vs-pointer, zero values, import grouping, dot imports, `//nolint` justification), and the ADR template + criteria.
+- [Google Go Style Guide / Decisions / Best Practices](https://google.github.io/styleguide/go/) (CC-BY-3.0) — Least Mechanism, naming form (MixedCaps, initialisms, constants), name length vs scope, `Get`-prefix and package-name-repetition rules, `util`/`common` prohibition, declaration style (`:=` vs `var`), nil-slice semantics, `%w` vs `%v` as an API decision, `error`-last and error-interface returns, `Must*` convention, signal boosting.
+- [Uber Go Style Guide](https://github.com/uber-go/guide) (Apache-2.0) — comma-ok type assertions, channel sizing, `init()` restrictions, no mutable globals, copy slices/maps at boundaries, mutex value/no-embed rules, predeclared-identifier shadowing, struct tags, `Printf`-style `f` suffix and const format strings, `os.Exit`-only-in-main, no `failed to` prefixes.
+- [metalagman `go-senior-developer`](https://github.com/metalagman/agent-skills) — bounded concurrency, atomics-vs-mutex split, secret redaction (rules extracted, prose rewritten).
 - Error taxonomy, dependency/CI policy, codegen, graceful shutdown, observability are ultimate-skill additions filling gaps in the source skills.

--- a/skills/go-ultimate/references/libraries.md
+++ b/skills/go-ultimate/references/libraries.md
@@ -157,6 +157,32 @@ func Old() *T { ... }
   identifier name.
 - Do not leak internal types through the public API (return error as `error`,
   not as `*internalError`).
+- **Assert interface compliance at compile time** where a type is meant to
+  satisfy an interface it does not name:
+
+  ```go
+  var _ io.ReadCloser = (*Stream)(nil)
+  ```
+
+  Zero cost, no allocation, and it turns "the caller's build broke" into "our
+  build broke" when a method signature drifts.
+- **Never take a pointer to an interface.** `*io.Reader` is almost always a
+  mistake: an interface value is already a reference pair. Use a pointer only for
+  the concrete type, when its methods must mutate it.
+
+### Document what the signature cannot say
+
+A doc comment that restates the signature is noise. These four facts cannot be
+inferred and must be written:
+
+- **Concurrency safety** — "safe for concurrent use by multiple goroutines", or
+  explicitly not. Callers otherwise guess, and guess wrong.
+- **Ownership and cleanup** — who closes what, and whether a returned value
+  aliases internal state. Anything returning an `io.Closer` says when to close it.
+- **Sentinel errors a caller is expected to match**, named in the doc comment of
+  the function that returns them.
+- **Non-obvious parameter constraints** — units, valid ranges, whether nil is
+  allowed and what it means.
 
 ---
 
@@ -173,4 +199,6 @@ func Old() *T { ... }
 
 - [powerman `go-engineering-policy` § Library Documentation](https://github.com/powerman/skills) — README vs `doc.go` split by audience.
 - Semver, major-version layout, public API stability, deprecation rules are ultimate-skill additions.
+- [Uber Go Style Guide](https://github.com/uber-go/guide) (Apache-2.0) — compile-time interface assertion, no pointers to interfaces.
+- [Google Go Best Practices](https://google.github.io/styleguide/go/best-practices) (CC-BY-3.0) — documenting concurrency safety, cleanup ownership, sentinel errors and parameter constraints.
 - Aligned with [engineering-policy.md](engineering-policy.md) (`go.mod` policy, Resolvable Config Struct, "accept interfaces, return structs").

--- a/skills/go-ultimate/references/modern-go.md
+++ b/skills/go-ultimate/references/modern-go.md
@@ -1,6 +1,8 @@
 # Modern Go — Version-Gated Syntax
 
-**Source:** condensed from [JetBrains `use-modern-go`](https://github.com/JetBrains/go-modern-guidelines/blob/main/claude/modern-go-guidelines/skills/use-modern-go/SKILL.md).
+**Source:** condensed from [JetBrains `use-modern-go`](https://github.com/JetBrains/go-modern-guidelines/blob/3a7f3eecd29f/claude/modern-go-guidelines/skills/use-modern-go/SKILL.md)
+(permalink to the revision this was condensed from — upstream has since replaced
+the markdown catalog with a CLI; see [§ Source](#source)).
 
 ## Detecting the target version
 
@@ -185,6 +187,27 @@ if pathErr, ok := errors.AsType[*os.PathError](err); ok {
 
 ## Source
 
-This reference condenses the JetBrains `use-modern-go` SKILL.md. The full
-per-version catalog with extensive before/after examples lives upstream:
-https://github.com/JetBrains/go-modern-guidelines/blob/main/claude/modern-go-guidelines/skills/use-modern-go/SKILL.md
+This reference condenses the JetBrains `use-modern-go` SKILL.md as it stood at
+commit [`3a7f3eecd29f`](https://github.com/JetBrains/go-modern-guidelines/blob/3a7f3eecd29f/claude/modern-go-guidelines/skills/use-modern-go/SKILL.md),
+which carried the full per-version catalog with before/after examples inline.
+
+**Upstream restructured on 2026-08-11**: the skill moved to
+[`plugin/skills/use-modern-go/SKILL.md`](https://github.com/JetBrains/go-modern-guidelines/blob/main/plugin/skills/use-modern-go/SKILL.md)
+and was rewritten from a static markdown catalog into a thin wrapper that shells
+out to a Modern Go Guidelines CLI (`list` / `explain` subcommands) which resolves
+guidelines at runtime. **The per-version catalog no longer exists upstream as
+readable markdown.**
+
+Consequences for this skill:
+
+- **The catalog below is now owned and maintained here**, the same way the
+  danicat material is (see SKILL.md `source-notes`). New Go releases must be
+  folded in by hand rather than diffed against upstream.
+- go-ultimate deliberately does **not** adopt the CLI approach: it would add a
+  runtime dependency on a third-party binary to a skill that is otherwise
+  self-contained, and version detection is already covered by the bundled
+  [`scripts/goversion/main.go`](../scripts/goversion/main.go). Revisit only if
+  the catalog becomes too costly to maintain by hand.
+- The upstream pin in
+  [`scripts/source-versions.json`](../scripts/source-versions.json) tracks the
+  new path, so a future change to the CLI-based skill is still detected.

--- a/skills/go-ultimate/references/production-readiness.md
+++ b/skills/go-ultimate/references/production-readiness.md
@@ -1,0 +1,325 @@
+# Production Readiness
+
+What a Go service needs beyond "it compiles and the tests pass". Read this when
+building, reviewing or hardening a **backend service**, a long-running MCP
+server, or a hosted agent — anything that runs unattended and that someone gets
+paged for.
+
+Scope boundary: [engineering-policy.md](engineering-policy.md) covers how the
+code is written; this covers how it behaves in production. Where the two touch
+(outbound HTTP, graceful shutdown, observability baseline), engineering-policy
+states the rule and this reference states the operational shape.
+
+## Contents
+
+- [Timeouts, retries, idempotency](#timeouts-retries-idempotency)
+- [The API error contract](#the-api-error-contract)
+- [Health and readiness](#health-and-readiness)
+- [Observability beyond logs](#observability-beyond-logs)
+- [Configuration and the 12-factor rules that matter](#configuration-and-the-12-factor-rules-that-matter)
+- [Secrets and hardening](#secrets-and-hardening)
+- [Data: migrations, transactions, outbox](#data-migrations-transactions-outbox)
+- [Performance work](#performance-work)
+- [The runbook](#the-runbook)
+- [Sources](#sources)
+
+---
+
+## Timeouts, retries, idempotency
+
+### Every network call is bounded
+
+No exceptions. A call without a deadline is an unbounded resource hold that
+turns one slow upstream into a cascading outage.
+
+- **Derive a new context with a timeout at every network or I/O boundary.** The
+  inbound request deadline is not enough — an upstream that is slower than your
+  own SLA must fail fast rather than consume your whole budget.
+- The `*http.Client` `Timeout` is the **backstop**, the per-call context is the
+  **budget**. Set both (see
+  [engineering-policy.md § Outbound HTTP](engineering-policy.md)).
+- Budget downward: if the handler has 2s, an upstream gets a fraction of it, not
+  all of it. Leave room to render an error.
+
+### Retry only what is safe to retry
+
+A retry is a correctness decision before it is a reliability one.
+
+- **Retry idempotent operations only.** `GET`, `PUT`, `DELETE` by natural key —
+  yes. A bare `POST` that creates something — no, unless it carries an
+  idempotency key (below).
+- **Exponential backoff with jitter**, always. Fixed-interval retries from many
+  clients synchronize into a thundering herd; jitter is what breaks the phase
+  lock, and it is not optional.
+- **Cap both the attempt count and the total elapsed time**, and abort the moment
+  `ctx.Done()` fires. A retry loop that outlives its caller's deadline is a leak.
+- **Do not retry what cannot succeed** — 4xx (except 429), validation failures,
+  context cancellation. Retrying a deterministic failure just multiplies load
+  during an incident.
+- Retries at more than one layer multiply. If the client retries 3× and the
+  gateway retries 3×, the upstream sees 9×. Pick **one** layer to own retries and
+  make the others pass failures through.
+
+Test backoff with `testing/synctest` rather than by sleeping — see
+[testing.md § Testing concurrent code](testing.md#testing-concurrent-code).
+
+### Idempotency keys
+
+For any API or job that creates or mutates state and that a client may retry:
+
+- The client supplies a key (header or field); the server stores
+  `key → result` and returns the **stored result** on a repeat, rather than
+  performing the work twice.
+- Decide the key's retention window explicitly and document it — an idempotency
+  record that expires sooner than the client's retry budget is not idempotency.
+- Design this **up front**. Retrofitting deduplication onto a live write path
+  means reconciling the duplicates that already happened.
+
+---
+
+## The API error contract
+
+An error surface is public API. Define it once, at the boundary, and keep it
+stable.
+
+```json
+{
+  "code": "rate_limited",
+  "message": "too many requests, retry after 30s",
+  "details": { "retry_after_seconds": 30 },
+  "request_id": "01JD7X2Q8M5V0K"
+}
+```
+
+- **`code`** is a stable machine-readable string. Clients branch on it, so it is
+  covered by your compatibility guarantees — see
+  [libraries.md § Semver and public API stability](libraries.md).
+- **`message`** is for humans and may change freely.
+- **`request_id`** appears in the response *and* in every log line for that
+  request. Without it, a user's bug report cannot be joined to your logs.
+- Map **domain errors to transport codes in the adapter**, never in the business
+  package — the domain does not know what HTTP is (non-negotiable principle 5).
+  A sentinel or typed error crosses the port; the adapter translates:
+
+  ```go
+  // internal/in/http — the only place that knows about status codes.
+  switch {
+  case errors.Is(err, app.ErrNotFound):
+      writeError(w, http.StatusNotFound, "not_found", err)
+  case errors.As(err, &verr):
+      writeError(w, http.StatusBadRequest, "invalid_argument", verr)
+  default:
+      // Never leak an internal error string to the client.
+      writeError(w, http.StatusInternalServerError, "internal", errInternal)
+  }
+  ```
+
+- **Never return a raw internal error to a client.** Log the detail with the
+  request id, return the code. Unwrapped errors leak table names, file paths and
+  upstream hostnames.
+
+---
+
+## Health and readiness
+
+Two endpoints, two different questions. Conflating them causes rolling deploys to
+either kill healthy pods or route traffic to dead ones.
+
+| Endpoint | Question | Fails when | Orchestrator reaction |
+|---|---|---|---|
+| `/healthz` (liveness) | Is the process alive? | Deadlock, unrecoverable state | Restart the container |
+| `/readyz` (readiness) | Can it serve traffic *now*? | A required dependency is down, still warming up, draining | Remove from the load balancer |
+
+- **Liveness must not check dependencies.** A liveness probe that pings the
+  database restarts every replica when the database blips — turning a
+  degradation into an outage.
+- **Readiness must reflect required dependencies** (DB, broker, cache if the
+  service cannot serve without it), with a short cached TTL so the probe does not
+  itself become load.
+- **On shutdown, fail readiness first**, then drain. The load balancer needs to
+  stop sending work before the server stops accepting it, or in-flight requests
+  die at the socket. See
+  [engineering-policy.md § Graceful shutdown](engineering-policy.md).
+
+---
+
+## Observability beyond logs
+
+[engineering-policy.md § Observability baseline](engineering-policy.md) sets the
+minimum: `log/slog`, a metrics registry, request-id plumbing. This is what a
+service that gets paged for actually needs.
+
+### Metrics
+
+Instrument the four signals that answer "is it broken and where":
+
+- **Latency** — histogram, so p95/p99 exist. An average latency metric cannot
+  detect the failure mode users notice.
+- **Error rate** — by `code`, matching the API error contract above.
+- **Throughput** — requests/messages per second.
+- **Saturation** — queue depth, pool utilization, worker occupancy. This is the
+  one that predicts the outage instead of reporting it.
+
+**Keep label cardinality bounded.** Never label a metric with a user id, request
+id, raw path, or any unbounded string — every distinct value is a new time
+series, and this is the standard way to take down a metrics backend.
+
+### Tracing
+
+- OpenTelemetry, propagated across **both** HTTP and messaging boundaries. A
+  trace that stops at the queue is a trace that stops exactly where the hard bugs
+  live.
+- Same cardinality discipline on span attributes.
+- Inbound adapters extract or generate the trace context; outbound adapters
+  inject it. Both are adapter concerns, not business-logic concerns.
+
+### SLOs
+
+- Track **p95/p99, not averages**, and define an error budget.
+- **Alert on symptoms, not causes.** "Checkout error rate above budget" pages
+  someone who can act; "CPU is 80%" pages someone at 3am for a healthy service.
+
+---
+
+## Configuration and the 12-factor rules that matter
+
+Not all twelve are worth restating. These four are the ones Go services get
+wrong:
+
+1. **Config comes from the environment**, and is read **once at startup** into
+   the business `Config` struct (see
+   [engineering-policy.md § Constructor pattern](engineering-policy.md)). Nothing
+   below `main` reads `os.Getenv` — that is what makes the code testable without
+   `t.Setenv`, and what keeps tests parallel.
+2. **Logs are an event stream to stdout.** The process never opens a log file,
+   never rotates one, never manages retention. The platform collects stdout.
+   Structured JSON in production; human-readable is a local-dev toggle.
+3. **`.env` is a local-development convenience only.** Provide a committed
+   `.env.example` listing every variable with a safe placeholder; never commit
+   `.env` itself (it is in the ignore baseline — see
+   [repo-and-ci.md](repo-and-ci.md)). Production configuration comes from the
+   platform's secret store, not from a file in the image.
+4. **Fail fast on bad configuration.** `Resolve()` validates at startup and the
+   process exits non-zero with a field-attributed error. A service that starts
+   with a missing required setting and fails on the first request has converted a
+   deploy-time error into a runtime incident.
+
+> A config library (`envconfig`, `viper`) is allowed but is not the default.
+> Plain `os.Getenv` into a `Config` struct with a `Resolve()` covers most
+> services without a dependency. Reach for a library when you genuinely need
+> layered sources (file + env + flags) or live reload.
+
+---
+
+## Secrets and hardening
+
+- **Never log a secret.** Give credential-bearing types a `String()`/`LogValue()`
+  that redacts, so an accidental `slog.Any("cfg", cfg)` cannot leak them. Relying
+  on reviewers to never log the wrong struct is not a control.
+- **Prefer short-lived credentials** (workload identity, STS, OIDC federation)
+  over static long-lived keys. When a static key is unavoidable, document its
+  rotation procedure in the runbook.
+- **Validate at the boundary, bound everything.** Size limits on request bodies
+  (`http.MaxBytesReader`), a cap on decompressed size, rate limits per client,
+  and a bound on any user-controlled iteration count. See
+  [code-review.md § Security](code-review.md).
+- **Container hardening:** run as a non-root user, read-only root filesystem
+  where possible, drop all capabilities, set resource requests and limits. A Go
+  binary is a static artifact — it should be running in a near-empty image with
+  no shell to be exploited.
+- Vulnerability scanning is `govulncheck` in CI — see
+  [repo-and-ci.md](repo-and-ci.md).
+
+---
+
+## Data: migrations, transactions, outbox
+
+### Migrations
+
+- Use a migration tool (`goose`, `atlas`, `golang-migrate`) — never hand-applied
+  SQL. Migrations are **checked into the repo** and **applied by CI/CD**, not by
+  a human at a psql prompt.
+- **Reversible where feasible.** When a down-migration is genuinely impossible
+  (a destructive backfill), say so explicitly in the migration file rather than
+  shipping a down that silently does nothing.
+- **Safe for rolling deploys.** During a rollout, old and new code run
+  simultaneously against one schema, so a migration must be compatible with
+  both. Destructive changes are a multi-deploy sequence, never one step:
+
+  | Goal | Wrong (breaks the rollout) | Right |
+  |---|---|---|
+  | Rename a column | `ALTER … RENAME` | add new → dual-write → backfill → switch reads → drop old |
+  | Drop a column | `DROP COLUMN` in the same deploy | stop writing → deploy → drop in a later migration |
+  | Add a `NOT NULL` column | add with `NOT NULL`, no default | add nullable → backfill → add constraint |
+
+- Adding an index on a large table locks writes on some engines — use the
+  concurrent form and expect it to run outside a transaction.
+
+### Transactions
+
+- **Keep transaction scope small.** Never hold a transaction across a network
+  call to another service; that couples your database's lock duration to a third
+  party's latency.
+- Pass `context.Context` into every DB operation so a cancelled request releases
+  its connection.
+- Be explicit about isolation level when the default is not right, and comment
+  *why* — the next reader cannot infer it.
+
+### The outbox pattern
+
+**"Write to the database, then publish an event" is a distributed-transaction
+bug.** If the publish fails after the commit, the event is lost forever; if the
+commit fails after the publish, consumers act on something that never happened.
+
+Instead: write the event to an `outbox` table **inside the same transaction** as
+the state change, and have a relay (poller or CDC stream) publish committed rows
+and mark them sent. This makes delivery at-least-once, which is why consumers
+must be idempotent — see [idempotency keys](#timeouts-retries-idempotency).
+
+---
+
+## Performance work
+
+**Measure first.** Every rule here is conditional on a profile showing the
+problem; applied speculatively they cost readability and buy nothing.
+
+- **`net/http/pprof` + `go tool pprof`** for CPU and heap profiles. In production,
+  expose pprof on a **separate internal-only listener**, never on the public
+  serving port — the profile endpoints are both expensive and revealing.
+- **`go build -gcflags="-m"`** to see escape-analysis decisions when allocation
+  volume is the problem.
+- **`go test -bench=. -benchmem`** to quantify before and after. A performance
+  change without a benchmark diff in the PR description is a guess.
+- **`sync.Pool`** for genuinely high-frequency, short-lived allocations of the
+  same type — after a profile shows GC pressure, not before. Misused, it holds
+  memory live and slows things down.
+- Prefer `strconv` over `fmt` for primitive-to-string conversion on hot paths,
+  and give `make()` a capacity hint when the size is known — these two are cheap
+  enough to apply without a profile.
+
+---
+
+## The runbook
+
+Every service ships a runbook — in the repo, next to the code, reviewed like
+code. Minimum contents:
+
+- **How to roll back**, with the exact command. During an incident nobody
+  reconstructs this from CI config.
+- **Where the dashboards and logs are** — direct links, not "in Grafana".
+- **How to enable `pprof` safely in production**, including which port and how
+  it is access-controlled.
+- **The top three alerts**: what each one means, what it does *not* mean, and the
+  first mitigation step for each.
+- **Credential rotation** for any static secret the service holds.
+
+An [ADR](engineering-policy.md) records *why* the architecture is what it is; the
+runbook records *what to do at 3am*. Both are required, and they are not the same
+document.
+
+---
+
+## Sources
+
+- [metalagman `go-senior-developer`](https://github.com/metalagman/agent-skills) — retries/idempotency, API error contract, health endpoints, observability signals, 12-factor selection, migrations/outbox, runbook contents, profiling tooling. Rules extracted and rewritten; see the skill's source-versions notes.
+- Cardinality discipline, the liveness-vs-readiness failure modes, the rolling-deploy migration table, the retry-multiplication rule and the secret-redaction control are this skill's additions.

--- a/skills/go-ultimate/references/repo-and-ci.md
+++ b/skills/go-ultimate/references/repo-and-ci.md
@@ -1,0 +1,382 @@
+# Repository and CI
+
+The files every Go repository must have, and the pipeline that enforces the rest
+of this skill. Read this when initializing a repository, reviewing repository
+hygiene, or setting up CI.
+
+[engineering-policy.md § Dependencies and CI](engineering-policy.md) states the
+mandatory gates; this reference is the concrete shape — the files, the workflow,
+and the tool-invocation policy.
+
+## Contents
+
+- [Required files](#required-files)
+- [Ignore baselines](#ignore-baselines)
+- [Tool invocation — `go tool`](#tool-invocation-go-tool)
+- [Linter configuration](#linter-configuration)
+- [GitHub Actions](#github-actions)
+- [Build reproducibility and version stamping](#build-reproducibility-and-version-stamping)
+- [Task runner](#task-runner)
+- [Containers](#containers)
+- [Sources](#sources)
+
+---
+
+## Required files
+
+Every Go repository, public or private, has all of these. A missing one is a
+review finding, not a nice-to-have.
+
+| File | Why |
+|---|---|
+| `LICENSE` | Without it the code is legally unusable by anyone else — "public on GitHub" is not a licence. Default to **MIT** unless the project says otherwise. |
+| `README.md` | What it is, how to install it, one runnable example. For libraries the bar is higher — see [libraries.md § README](libraries.md). |
+| `AGENTS.md` | Project-specific conventions for AI agents. This skill defers to it (SKILL.md § Project-file precedence), so it is where a project records its legitimate deviations. |
+| `.gitignore` | Below. |
+| `.dockerignore` | Any repo that builds an image. Without it the build context includes `.git/` and every local artifact, which is both slow and a secret-leak path. |
+| `.golangci.yml` | The lint contract, versioned with the code. |
+| `.github/workflows/` | Lint and test gates on every PR. |
+
+`AGENTS.md` should be short and specific — the deviations, not a restatement of
+general Go practice:
+
+```markdown
+# AGENTS
+
+## Conventions
+- Go version: as pinned in `go.mod`. Do not raise it without an ADR.
+- Run `go tool golangci-lint run ./...` and `go test -race ./...` before pushing.
+- Deviations from go-ultimate: <none | list them with the reason>
+
+## Layout
+- <anything a reader could not infer from the tree>
+```
+
+> **When a project already has one of these, merge — do not overwrite.** Adding
+> the missing baseline patterns to an existing `.gitignore` is correct;
+> replacing it wholesale deletes project-specific entries that someone added for
+> a reason. The same applies to `AGENTS.md` and `.golangci.yml`.
+
+---
+
+## Ignore baselines
+
+### `.gitignore`
+
+Cover four categories. Anything less and build artifacts end up in review diffs.
+
+```gitignore
+# Binaries and build output
+bin/
+dist/
+*.exe
+*.test
+
+# Test and coverage output
+*.coverprofile
+coverage.out
+coverage.html
+
+# Tool caches
+.cache/
+.gocache/
+.gomodcache/
+
+# Editors and IDEs
+.idea/
+.vscode/
+*.swp
+*~
+
+# OS noise
+.DS_Store
+Thumbs.db
+
+# Local configuration — never commit real values
+.env
+```
+
+Note what is **not** here: `vendor/` is only ignored if the project has decided
+not to vendor. If it vendors, `vendor/` is committed on purpose.
+
+### `.dockerignore`
+
+The build context should contain the source needed to compile and nothing else:
+
+```dockerignore
+.git/
+.github/
+bin/
+dist/
+*.md
+.env
+testdata/
+Dockerfile
+```
+
+### `.aiignore` (optional)
+
+Keeps AI agents out of files that waste context or should not be read — large
+generated files, binary assets, vendored trees:
+
+```gitignore
+bin/
+vendor/
+*.generated.go
+*.pb.go
+*.png
+*.jpg
+*.pdf
+*.log
+```
+
+This is a convention, not a standard: support varies by harness, so treat it as a
+hint rather than an access control.
+
+---
+
+## Tool invocation: `go tool`
+
+**Pin every tool in `go.mod` with the `tool` directive (Go 1.24+) and invoke it
+through `go tool`.** Never the old `tools.go` blank-import hack, and never a
+bare `go install` that resolves to whatever the developer happens to have.
+
+```console
+$ go get -tool github.com/golangci/golangci-lint/v2/cmd/golangci-lint@latest
+$ go tool golangci-lint run ./...
+```
+
+The point is that CI, every developer, and every agent run the **same version**.
+An unpinned linter means a PR that is green locally and red in CI for reasons
+nobody can reproduce; an unpinned generator means checked-in generated code that
+churns from machine to machine ([engineering-policy.md § Code
+generation](engineering-policy.md)).
+
+> **When tool dependencies pollute the main module** — `golangci-lint` in
+> particular pulls a large graph into `go.sum` — isolate them in a dedicated
+> `tools/go.mod`. That keeps the library's own dependency graph honest, which
+> matters for anything others import. For applications, the churn is usually
+> acceptable and one module is simpler.
+
+---
+
+## Linter configuration
+
+The mandatory linter set is in
+[engineering-policy.md § Linting](engineering-policy.md). Two rules about the
+config file itself:
+
+- **Version the config with the code.** `.golangci.yml` at the repo root, in git.
+  A lint standard that lives in someone's CI settings is not a standard.
+- **Pin the `golangci-lint` version in CI.** The linter changes what it reports
+  between minor versions; an unpinned linter turns an unrelated PR red.
+
+### Strict configurations
+
+For a new project with no legacy to grandfather, a curated strict config is a
+better starting point than assembling one by hand —
+[`powerman/golangci-lint-strict`](https://github.com/powerman/golangci-lint-strict)
+publishes one config per exact `golangci-lint` version.
+
+If you adopt it:
+
+- **Fetch the config for the exact `golangci-lint` version you run.** Config
+  schema changes between versions; a mismatched config fails to parse or silently
+  ignores sections.
+- **Do not edit the upstream file.** Keeping it byte-identical is the whole
+  point: it makes lint behavior reproducible and upgrades mechanical. Put
+  project overrides in a separate config that extends it, or accept a rule and
+  fix the code.
+- **Never overwrite an existing `.golangci.yml` without asking.** Back it up
+  first; a project's exclusions usually encode decisions nobody wrote down.
+
+This is an **opt-in upgrade**, not the skill's default. The default remains the
+explicit linter list in engineering-policy — it is small enough to read, argue
+with, and own.
+
+---
+
+## GitHub Actions
+
+### Pin the Go version to `go.mod`, not to the workflow
+
+```yaml
+- uses: actions/setup-go@v5
+  with:
+    go-version-file: go.mod
+```
+
+`go-version-file` means the version lives in exactly one place. A hardcoded
+`go-version: '1.25'` in the workflow silently diverges from `go.mod` the first
+time someone bumps one and not the other, and then CI is testing a different
+language version than the code declares.
+
+### Minimum workflow
+
+```yaml
+name: CI
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ci-${{ github.event_name }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+      - run: go build ./...
+      - run: go vet ./...
+      - run: go test -race -cover ./...
+      - name: modules are tidy
+        run: |
+          go mod tidy
+          git diff --exit-code -- go.mod go.sum
+
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+      - uses: golangci/golangci-lint-action@v7
+        with:
+          version: v2.12   # pinned on purpose
+
+  vuln:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+      - run: go run golang.org/x/vuln/cmd/govulncheck@latest ./...
+```
+
+Ready-to-copy versions of these two jobs are in
+[`assets/ci/`](../assets/ci/).
+
+Details that matter:
+
+- **`permissions: contents: read`** — the default token is over-privileged.
+  Grant per-job what a job actually needs.
+- **`concurrency` with `cancel-in-progress`** — a stale run on an amended PR is
+  wasted minutes. Include `github.event_name` in the group so a `push` and a
+  `pull_request` for the same ref do not cancel each other.
+- **Pin actions to a major tag** at minimum; pin to a commit SHA for anything
+  handling secrets.
+- **The tidy check is `go mod tidy` + `git diff --exit-code`** (or
+  `go mod tidy -diff` on Go 1.23+). Without it, `go.sum` drifts until someone's
+  build breaks for an unrelated reason.
+
+### Library repositories: test the supported range
+
+An application tests the one version it ships. A library must test the versions
+it claims to support — at minimum the `go.mod` floor and the current release:
+
+```yaml
+strategy:
+  matrix:
+    go: ['1.25', '1.26']
+```
+
+See [engineering-policy.md § `go.mod` version policy](engineering-policy.md) for
+which floor a library should declare.
+
+---
+
+## Build reproducibility and version stamping
+
+A binary in production must be traceable to a commit.
+
+```console
+$ go build -trimpath \
+    -ldflags "-X main.version=$(git describe --tags --always) \
+              -X main.commit=$(git rev-parse --short HEAD) \
+              -X main.date=$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+    ./cmd/myapp
+```
+
+- **`-trimpath`** removes local filesystem paths from the binary, which is what
+  makes the build reproducible across machines and stops it leaking
+  `/Users/you/...` into stack traces.
+- **Stamp version, commit and build date** via `-ldflags -X`, and expose them
+  through a `--version` flag. "Which build is running?" must be answerable from
+  the running process, not inferred from a deploy log.
+- On Go 1.24+, much of this is also available at runtime from
+  `runtime/debug.ReadBuildInfo()` — use it for VCS revision and dependency
+  versions rather than stamping what the toolchain already records.
+
+For tagged releases, `goreleaser` is the common choice and handles the above plus
+checksums, archives and SBOM generation. It is a fine default for a CLI
+distributed as binaries; it is unnecessary for a library.
+
+---
+
+## Task runner
+
+Standardize the entry points so that a contributor — or an agent — does not have
+to reverse-engineer the pipeline from CI YAML:
+
+```makefile
+.PHONY: lint test generate build
+lint:     ; go tool golangci-lint run ./...
+test:     ; go test -race -cover ./...
+generate: ; go generate ./...
+build:    ; go build ./...
+```
+
+`make lint`, `make test`, `make generate`, `make build` (or the Taskfile
+equivalents). **CI runs the same targets** — if CI and the Makefile drift, the
+Makefile becomes a lie and everyone goes back to reading the YAML.
+
+---
+
+## Containers
+
+Use a **multi-stage build**. The final image contains the binary and its
+runtime dependencies, nothing else — no toolchain, no source, no module cache.
+
+```dockerfile
+FROM golang:1.26 AS build
+WORKDIR /src
+COPY go.mod go.sum ./
+RUN go mod download
+COPY . .
+RUN CGO_ENABLED=0 go build -trimpath -o /out/app ./cmd/app
+
+FROM gcr.io/distroless/static-nonroot
+COPY --from=build /out/app /app
+USER nonroot:nonroot
+ENTRYPOINT ["/app"]
+```
+
+- **Copy `go.mod`/`go.sum` and run `go mod download` before copying the source**
+  so the dependency layer stays cached across source changes.
+- **`CGO_ENABLED=0`** for a static binary, which is what lets the runtime stage
+  be `distroless/static` or `scratch`. If the build genuinely needs cgo, the
+  runtime stage needs a matching libc.
+- **Run as non-root.** See
+  [production-readiness.md § Secrets and hardening](production-readiness.md).
+- Place the `Dockerfile` where the project expects it — repo root for a single
+  binary, next to the entrypoint or under `build/` for several.
+
+---
+
+## Sources
+
+- [metalagman `go-oss-maintainer`](https://github.com/metalagman/agent-skills) — required-file set, ignore baselines, the merge-don't-overwrite rule, `go-version-file: go.mod`, `go tool` invocation policy.
+- [metalagman `golangci-lint-strict`](https://github.com/metalagman/agent-skills) + [powerman/golangci-lint-strict](https://github.com/powerman/golangci-lint-strict) — exact-version config pinning, do-not-edit-upstream rule.
+- [metalagman `go-senior-developer`](https://github.com/metalagman/agent-skills) — `-trimpath`/`-ldflags` stamping, task-runner standardization, multi-stage Docker default, tools-module isolation.
+- Workflow permissions/concurrency shape, the library test matrix, and the layer-caching Dockerfile ordering are this skill's additions.

--- a/skills/go-ultimate/references/testing.md
+++ b/skills/go-ultimate/references/testing.md
@@ -121,6 +121,51 @@ func TestDoThing(t *testing.T) {
 }
 ```
 
+## Runnable examples
+
+`Example` functions in the external test package are **tests and documentation at
+once**: `go test` runs them and compares stdout to the `// Output:` comment, and
+`go doc`/pkg.go.dev renders them on the package page. Documentation that cannot
+silently go stale.
+
+```go
+func ExampleClient_Get() {
+    c := api.NewClient(api.Config{})
+    u, _ := c.Get(context.Background(), 1)
+    fmt.Println(u.Name)
+    // Output: Ada
+}
+```
+
+- Naming binds the example to its subject: `Example`, `ExampleT`, `ExampleF`,
+  `ExampleT_M`, plus an optional lowercase suffix (`ExampleClient_Get_notFound`).
+- **An example without an `// Output:` comment is compiled but never run** — it
+  checks nothing. Use `// Unordered output:` when map iteration makes ordering
+  unstable.
+- Every exported package gets at least one example showing the primary use case.
+  For libraries this is mandatory — see [libraries.md](libraries.md).
+
+## Contract tests
+
+When an API is defined by a spec (OpenAPI, AsyncAPI, protobuf), **the spec is the
+test fixture**. Validate real request/response pairs against the schema rather
+than asserting on a hand-written copy of what you believe the spec says.
+
+- Generate the server stubs and clients from the spec — a generated client that
+  compiles is already a compatibility check
+  ([engineering-policy.md § Code generation](engineering-policy.md)).
+- Run consumer/provider checks where a real consumer exists, so a
+  backward-incompatible change fails in your CI rather than theirs.
+- A hand-maintained mirror of the schema inside the tests drifts and then asserts
+  the wrong contract confidently. Point at the spec file itself.
+
+## Benchmarks
+
+`go test -bench=. -benchmem` is the only acceptable evidence for a performance
+claim. Benchmark before and after, and put the diff in the PR description.
+Profiling tooling and when to reach for it are in
+[production-readiness.md § Performance work](production-readiness.md).
+
 ## Testing concurrent code
 
 **Use `testing/synctest` (Go 1.25+) for anything involving time or goroutine
@@ -234,11 +279,29 @@ it with `go build -cover` and collect profiles via `GOCOVERDIR`.
 - Generate mocks for **all In/Out ports** in service architectures (see
   [architecture.md](architecture.md)).
 
-`//go:generate` directive example:
+`//go:generate` directive example — through `go tool` so every machine runs the
+version pinned in `go.mod` (see
+[engineering-policy.md § Code generation](engineering-policy.md)):
 
 ```go
-//go:generate mockgen -destination=mocks/port_mock.go -package=mocks example.com/proj/internal/port App,Repo
+//go:generate go tool mockgen -destination=mocks/port_mock.go -package=mocks example.com/proj/internal/port App,Repo
 ```
+
+### Naming test doubles
+
+A consistent name says what the double *does*, so a reader does not have to open
+it:
+
+- **Package** — append `test` to the package being faked: `creditcardtest`,
+  `storagetest`. It ships beside the real package and is importable by other
+  packages' tests.
+- **Type** — name it for its behavior, not its mechanism: `AlwaysCharges`,
+  `RejectsExpired`, `EmptyStore`. A generic `Stub`/`Fake` is fine when the
+  package holds exactly one.
+- **Variable** — prefix with the double's kind: `spyCC`, `stubClock`, `mockRepo`.
+
+Do not name a double after the interface it implements (`MockPortApp`) and stop
+there — that says how it was generated, not what the test expects of it.
 
 ## Test strategy by layer (services)
 
@@ -274,4 +337,6 @@ it with `go build -cover` and collect profiles via `GOCOVERDIR`.
 ## Sources
 
 - [powerman `go-engineering-policy`](https://github.com/powerman/skills) — testing section, gomock + go-mockgen.
+- [Google Go Best Practices](https://google.github.io/styleguide/go/best-practices) (CC-BY-3.0) — test-double naming (package/type/variable), runnable examples as documentation.
+- [metalagman `go-senior-developer`](https://github.com/metalagman/agent-skills) — contract tests against OpenAPI/AsyncAPI, benchmark discipline (rules extracted, prose rewritten).
 - Assertion-library choice (`vanilla` default, testify as fallback) is this skill's own resolution of a donor disagreement — the donors split on whether to prefer an assertion library.

--- a/skills/go-ultimate/scripts/source-versions.json
+++ b/skills/go-ultimate/scripts/source-versions.json
@@ -12,8 +12,11 @@
     "jetbrains-modern-go": {
       "kind": "github-path",
       "repo": "JetBrains/go-modern-guidelines",
-      "path": "claude/modern-go-guidelines/skills/use-modern-go/SKILL.md",
-      "commit_sha": "3a7f3eecd29f",
+      "path": "plugin/skills/use-modern-go/SKILL.md",
+      "commit_sha": "7b56a40ab86f",
+      "condensed_from_sha": "3a7f3eecd29f",
+      "old_path": "claude/modern-go-guidelines/skills/use-modern-go/SKILL.md",
+      "_note": "Upstream restructured on 2026-08-11: the skill moved from old_path to plugin/skills/use-modern-go/SKILL.md AND was rewritten from a static per-version markdown catalog into a thin wrapper around a Modern Go Guidelines CLI (list/explain subcommands, installed on first use). 198b4e1c8534 is the commit that removed the old path; 7b56a40ab86f is the current head of the new one. The catalog no longer exists upstream as readable markdown, so references/modern-go.md now owns that content (danicat precedent) and new Go releases are folded in by hand. condensed_from_sha records the last revision that still carried the catalog — it is also the permalink cited in references/modern-go.md, since linking the current file would point at material that no longer contains what was condensed. The pin tracks the new path so future changes to the CLI-based skill are still detected, but drift there is no longer a signal to re-condense.",
       "doc_ref": "references/modern-go.md"
     },
     "powerman-bch": {

--- a/skills/go-ultimate/scripts/source-versions.json
+++ b/skills/go-ultimate/scripts/source-versions.json
@@ -1,6 +1,6 @@
 {
   "_comment": "Baseline pins for go-ultimate's donor sources. Used by scripts/check-source-versions.sh to detect upstream drift. Update a pin whenever you fold a change from that donor back into the skill (and bump SKILL.md version). Pin types: commit_sha = last commit touching a GitHub path (kind: github-path); tag = latest stable release/tag (kind: github-tag); manual-review = not auto-checked, records last_reviewed date (kind: manual-review).",
-  "_updated": "2026-07-26",
+  "_updated": "2026-08-19",
   "sources": {
     "teetsh-review": {
       "kind": "github-path",
@@ -60,8 +60,54 @@
       "last_reviewed": "2026-08-06",
       "_note": "Page is undated. Not auto-checked (see philschmid entry). Update last_reviewed after each review.",
       "doc_ref": "references/mcp-server.md"
+    },
+    "google-styleguide-go": {
+      "kind": "github-path",
+      "repo": "google/styleguide",
+      "path": "go",
+      "commit_sha": "c098353acb6d",
+      "license": "CC-BY-3.0",
+      "_note": "Google Go Style Guide + Decisions + Best Practices. Rules folded into engineering-policy (naming form, Least Mechanism, declarations, %w-vs-%v), testing (test-double naming, runnable examples) and libraries (documentation duties). Not vendored verbatim; attribution required by CC-BY.",
+      "doc_ref": "references/engineering-policy.md, references/testing.md, references/libraries.md, references/code-review.md"
+    },
+    "uber-go-guide": {
+      "kind": "github-path",
+      "repo": "uber-go/guide",
+      "path": "style.md",
+      "commit_sha": "37c45b52bf9a",
+      "license": "Apache-2.0",
+      "_note": "Uber Go Style Guide. Rules folded into engineering-policy (comma-ok, channel sizing, init() restrictions, no mutable globals, slice/map copying, mutex discipline) and libraries (compile-time interface assertion, no interface pointers). Deliberately NOT adopted: the `_` prefix for unexported top-level vars, go.uber.org/atomic (superseded by typed sync/atomic), and the 99-char soft line limit (Google's refactor-instead-of-wrap rule wins).",
+      "doc_ref": "references/engineering-policy.md, references/libraries.md, references/code-review.md"
+    },
+    "metalagman-senior-developer": {
+      "kind": "github-path",
+      "repo": "metalagman/agent-skills",
+      "path": "go-senior-developer/SKILL.md",
+      "commit_sha": "c4c55848a628",
+      "license": "NONE — see _license_note",
+      "_note": "Source for references/production-readiness.md (retries/idempotency, API error contract, health endpoints, observability signals, 12-factor selection, migrations/outbox, runbook, profiling) plus bounded concurrency and build stamping. Deliberately NOT adopted: pkg/ for external consumption, uber-go/fx as the DI default, options-gen as the config pattern, Gitflow — all conflict with this skill's mandates.",
+      "doc_ref": "references/production-readiness.md, references/repo-and-ci.md, references/engineering-policy.md, references/testing.md"
+    },
+    "metalagman-oss-maintainer": {
+      "kind": "github-path",
+      "repo": "metalagman/agent-skills",
+      "path": "go-oss-maintainer/SKILL.md",
+      "commit_sha": "4eda551d7bb7",
+      "license": "NONE — see _license_note",
+      "_note": "Source for references/repo-and-ci.md (required-file set, ignore baselines, merge-don't-overwrite rule, go-version-file: go.mod, go tool invocation policy) and assets/ci/.",
+      "doc_ref": "references/repo-and-ci.md, assets/ci/"
+    },
+    "metalagman-golangci-strict": {
+      "kind": "github-path",
+      "repo": "metalagman/agent-skills",
+      "path": "golangci-lint-strict/SKILL.md",
+      "commit_sha": "7dd5ad3c011a",
+      "license": "NONE — see _license_note",
+      "_note": "Source for the opt-in strict-config section of references/repo-and-ci.md (exact-version pinning, do-not-edit-upstream, ask-before-overwrite). The skill's default remains its own explicit linter list, not the strict config.",
+      "doc_ref": "references/repo-and-ci.md"
     }
   },
+  "_license_note": "metalagman/agent-skills ships no LICENSE file, so its text is all-rights-reserved by default. Nothing is copied verbatim: rules were extracted and rewritten in this skill's voice, with the donor credited in each affected reference. Its bulk style-guide documents are derivatives of google/styleguide (CC-BY-3.0) and uber-go/guide (Apache-2.0), which this skill pins and attributes directly from upstream instead. If metalagman adds a permissive licence, this note can be simplified.",
   "no_longer_tracked": {
     "danicat-best-practices": "Deleted upstream 2026-07-21 (commit 201fa420). Content folded into references/engineering-policy.md + references/code-review.md.",
     "danicat-project-setup": "Deleted upstream 2026-07-21 (commit 201fa420). Boilerplates now owned by this skill under assets/."


### PR DESCRIPTION
Goes through metalagman/agent-skills and pulls out what's useful.

**Note:** it's better to merge #28 first to avoid a rebase.

---

## The structural decision

**One skill — but only for the material that belongs in one.**

The value of go-ultimate is that it is singular: it auto-triggers on any Go task, routes through one decision tree, and resolves conflicts on one precedence ladder. Anything that is a *rule about how to write Go* belongs inside it, and this PR folds ~80% of the donor's value in that way, without adding a single new skill.

What does **not** belong in it is the donor's per-tool playbooks — `go-fx`, `go-goose`, `go-options-gen`, `go-adk` — for three reasons:

1. **They contradict our own mandates.** Fx vs. hand-written `wire.go`, options-gen vs. the Resolvable Config Struct. Shipping both inside one always-on skill means shipping a contradiction.
2. **The skill declares itself `REQUIRED for ALL Go work`.** Loading a goose tutorial into every Go session is context paid for something ~5% of tasks need.
3. **They are version-fragile** (ADK v1.2.0, goose's provider API) and want their own update cadence, not a go-ultimate release.

Those four are therefore **out of scope for this PR by decision, not by oversight** — recorded as such in `README.md` and `source-versions.json` so it does not have to be re-litigated. If we ever want them, they should be sibling skills under `skills/`, which every plugin manifest already points at (`"skills": "./skills/"`), so no manifest changes would be needed. That is a product-positioning call for the maintainer, not something to smuggle in here.

---

## What's new

### `references/production-readiness.md` (325 lines)

The largest genuine gap. Today the skill's entire treatment of running a service in production is an eight-line "Observability baseline". This reference covers what a service actually needs before launch:

- **Timeouts, retries, idempotency** — every network call bounded and budgeted downward; retries only on idempotent operations, with backoff + jitter, a cap, and `ctx.Done()` honored; the retry-multiplication trap (client 3× × gateway 3× = 9× on the upstream); idempotency keys designed up front.
- **The API error contract** — a stable `code`/`message`/`details`/`request_id` schema, domain→transport mapping performed *in the adapter* (this is non-negotiable principle 5 applied to errors), and never returning a raw internal error to a client.
- **Health and readiness** — a table separating the two, because conflating them is how a database blip becomes a full restart loop. Readiness fails first on shutdown, before draining.
- **Observability beyond logs** — the four signals worth instrumenting, and a hard rule on **bounded label cardinality** (no user id, request id or raw path on a metric or span) since that is the standard way to take down a metrics backend.
- **12-factor, the four rules Go services get wrong** — config read once at startup (nothing below `main` calls `os.Getenv`, which is what keeps tests parallel), logs as a stdout event stream, `.env` as local-dev-only with a committed `.env.example`, and fail-fast config validation.
- **Secrets and hardening** — redacting `LogValue()`/`String()` on credential-bearing types so an accidental `slog.Any("cfg", cfg)` cannot leak them; short-lived credentials; non-root, read-only-FS, dropped-capability containers.
- **Data** — a table of rolling-deploy-safe migration sequences (rename, drop, add `NOT NULL`), small transaction scopes, and the **outbox pattern**, with the "commit then publish" dual-write named as the bug it is.
- **Performance work** — `pprof` on a separate internal-only listener, `-gcflags=-m`, `-benchmem`, `sync.Pool` only after a profile.
- **The runbook** as a required artifact, and why it is not the same document as an ADR.

Mandatory for `BACKEND SERVICE`; conditional for hosted MCP servers and agents.

### `references/repo-and-ci.md` (382 lines)

The engineering policy states which CI gates are mandatory but never says what the files look like. This is that:

- **Required-file set** — `LICENSE`, `README.md`, `AGENTS.md`, `.gitignore`, `.dockerignore`, `.golangci.yml`, workflows — with the operational rule that when one already exists you **merge the missing baseline into it, never overwrite** (someone's exclusions usually encode a decision nobody wrote down).
- **`go tool` invocation policy** — every tool pinned via the `tool` directive, never `go install`, never `tools.go`; plus when to isolate tools in a separate `tools/go.mod`.
- **Workflow shape** — `go-version-file: go.mod` so the Go version lives in exactly one place, a pinned `golangci-lint` version, scoped `permissions`, `concurrency` with `cancel-in-progress`, and the tidy check.
- **Strict lint configs** as an **opt-in upgrade**, not a new default: fetch the `powerman/golangci-lint-strict` config matching your exact `golangci-lint` version, never edit it, never overwrite an existing config without asking. Our explicit twelve-linter list stays the default — it is short enough to read, argue with, and own.
- **Build reproducibility** — `-trimpath`, `-ldflags` version stamping, a `--version` flag, and what `debug.ReadBuildInfo()` already gives you for free.
- **Task runner** and a **multi-stage Dockerfile** with correct layer-cache ordering.

### `assets/ci/{test,lint}.yml`

Copy-paste workflows implementing the mandatory gates, with a commented-out `compat` matrix job to uncomment for libraries (which must test their supported range) and delete for applications (which ship one version).

---

## Rules folded into existing references

| File | Added |
|---|---|
| `engineering-policy.md` (556 → 841) | New **§ Globals and `init()`**: no mutable globals, no goroutines/I-O/ordering-dependence in `init()`. New **§ Least Mechanism** — the principle already implicit behind vanilla `testing`, the Config struct, and hand-written wiring. **§ Style**: comma-ok on every type assertion, named fields in composite literals, `:=` vs `var`, nil-slice semantics, slice/map copying at API boundaries, no shadowing predeclared identifiers, struct tags, const format strings + `Printf`-style `f` suffix, signal boosting. **§ Errors**: `error` last, exported functions return the `error` interface, `os.Exit`/`log.Fatal` only in `main`, the `Must*` convention, no `failed to` prefixes. **§ Naming**: MixedCaps, initialism casing, constants, name-length-vs-scope, no type in name, no package-name repetition, no `Get` prefix, the `util`/`common`/`helpers` prohibition, receiver consistency. **§ Concurrency**: bounded fan-out, channel sizing, mutex value/no-embed rules, atomics vs mutex. |
| `testing.md` | Test-double naming (`creditcardtest`, `AlwaysCharges`, `spyCC`), runnable `Example` functions incl. the trap that one without `// Output:` never runs, contract tests against OpenAPI/AsyncAPI, benchmark discipline. Also fixes an internal inconsistency: `//go:generate mockgen` → `go tool mockgen`, matching the policy the same skill mandates for generators. |
| `libraries.md` | Compile-time interface assertion (`var _ I = (*T)(nil)`), no pointers to interfaces, and the four facts a doc comment must state that a signature cannot: concurrency safety, cleanup ownership, matchable sentinels, parameter constraints. |
| `code-review.md` | Checklist items mirroring all of the above, plus a new **Production readiness** review area for long-running services. |
| `SKILL.md` | Routing to both new references, eight new quick-reference rows, precedence ladder items 8 and 9 (both explicitly *refining* rule 3 rather than competing with it). |
| `evals/README.md` | Eval 6 (production readiness — the payment-retry and dual-write traps) and Eval 7 (repository hygiene — hardcoded Go version, `tools.go`, silent overwrite, missing LICENSE as failure signals). |

### One rule change worth calling out

`engineering-policy.md` previously said, unconditionally, *"wrap with `fmt.Errorf("...: %w", err)`"*. That is now qualified: **`%w` makes the wrapped error part of your package's contract**, so it is an API decision, not a formatting habit. `%w` within a bounded context where you own both sides; `%v` when re-exporting a dependency's error across a public boundary, unless you are deliberately promoting it to contract. This is the one place a donor genuinely corrected us rather than merely adding to us.

---

## Deliberately not adopted

Recorded in `source-versions.json` per donor, so the next person does not re-import them:

| Rejected | Why |
|---|---|
| `pkg/` for "externally consumable" code | Non-negotiable principle 2. |
| Fx as the DI default | We mandate hand-written `wire.go` / google-wire. |
| options-gen as the config pattern | We mandate the Resolvable Config Struct. |
| Gitflow, viper/envconfig as defaults | Out of scope / not our default. |
| Uber's `_` prefix for unexported top-level vars | Idiosyncratic; conflicts with our naming section. |
| `go.uber.org/atomic` | Superseded by typed `sync/atomic` (`atomic.Int64`, `atomic.Pointer[T]`). |
| Uber's 99-char soft line limit | Conflicts with Google's "no fixed limit — refactor instead of wrapping". We take Google's. |
| Everything non-Go (`beads`, `gitflow`, `github-flow`, `conventional-commits`, `omnidist`) | Out of scope. |

`skill-writer` is also not folded in, but its progressive-disclosure model and QA checklist would sit well in this repo's own contributor docs if we ever want them.

---

## Licensing and attribution

**`metalagman/agent-skills` ships no `LICENSE` file**, so its text is all-rights-reserved by default. Handling:

- **Nothing is copied verbatim.** Rules were extracted and rewritten in this skill's voice; the donor is credited in the Sources section of every affected reference and in `SKILL.md`'s `source-notes`.
- **The bulk style-guide documents there are derivatives** of [google/styleguide](https://google.github.io/styleguide/go/) (CC-BY-3.0) and [uber-go/guide](https://github.com/uber-go/guide) (Apache-2.0). This PR pins and attributes **both directly from upstream** instead of routing through the donor, which removes the licence gap entirely and gives us better drift detection at the same time.
- Worth asking metalagman to add a licence — it would let us simplify the note.

Five new pins in `source-versions.json`, all verified green by `check-source-versions.sh`:

| Source | Kind | Pin |
|---|---|---|
| `google/styleguide` (`go/`) | github-path | `c098353acb6d` |
| `uber-go/guide` (`style.md`) | github-path | `37c45b52bf9a` |
| `metalagman/agent-skills#go-senior-developer` | github-path | `c4c55848a628` |
| `metalagman/agent-skills#go-oss-maintainer` | github-path | `4eda551d7bb7` |
| `metalagman/agent-skills#golangci-lint-strict` | github-path | `7dd5ad3c011a` |

---

## Second commit: a rotted donor link, and what it revealed

The `markdown links` job failed on two 404s in `references/modern-go.md` — a file this PR does not otherwise touch. The cause is upstream: **JetBrains/go-modern-guidelines restructured on 2026-08-11.** The skill moved path *and* was rewritten from a 291-line static per-version markdown catalog into a 66-line wrapper around a Modern Go Guidelines CLI (`list` / `explain`, installed into a cache directory on first use).

So this is not just a dead URL. **The catalog we condensed no longer exists upstream as readable markdown**, which means:

- `references/modern-go.md` now cites a **permalink at `3a7f3eecd29f`**, the last revision that still carried the catalog. Pointing at the current file would link to material that no longer contains what was condensed.
- Its `§ Source` now records the restructure and states that **the catalog is henceforth owned and maintained here** — the same situation as the deleted danicat skills. Practical consequence: new Go releases get folded in by hand rather than diffed against upstream.
- **The CLI approach is deliberately not adopted.** It would add a runtime dependency on a third-party binary to a skill that is otherwise self-contained, and version detection is already covered by the bundled `scripts/goversion/main.go`. Worth revisiting only if hand-maintaining the catalog becomes expensive — flagging it as a real decision rather than silently declining.
- `source-versions.json` tracks the **new** path at `7b56a40ab86f`, keeping `old_path` and `condensed_from_sha` for provenance, so future changes to the CLI-based skill are still detected — but drift there is no longer a signal to re-condense. (`198b4e1c8534` is the commit that *removed* the old path; the new path was created by sibling commits in the same push, which is why the pin is not that SHA.)
- `SKILL.md` gains a `jetbrains-restructured` source-note.

## Verification

- `check-version-consistency.sh` → **0.11.0 across all 7 locations** (SKILL.md, README.md, 5 plugin manifests).
- All relative markdown links resolve (CI's lychee job).
- `gofmt -l .` clean. **No `.go` files touched**, so the template matrix job is unaffected.
- All five plugin manifests re-validated with `jq` and kept at their original formatting — the diffs are the version line only (plus the description on `.claude-plugin`, which was stale about the donor count).
- `check-source-versions.sh` → all five new pins `ok`.

`18 files changed, 1465 insertions(+), 22 deletions(-)`

---

## Out of scope — pre-existing drift, for a separate PR

`check-source-versions.sh` reported drift in three donors that **predates this branch**. The JetBrains one is resolved above (it was breaking CI). Two remain:

| Donor | Pinned | Upstream now |
|---|---|---|
| `cloudwego/eino` | v0.9.13 | v0.9.15 |
| `modelcontextprotocol/go-sdk` | v1.6.1 | **v1.7.0** |

The go-sdk one matters most: the note in `source-versions.json` says *"v1.7.0-pre.x targets the not-yet-final 2026-07-28 MCP protocol"* — that protocol has since been finalised and v1.7.0 released, so `references/mcp-server.md` and `assets/mcp-server/` want a look. Not folded in here to keep this PR reviewable.

Neither gates this PR: the drift check runs on its own schedule (`source-versions.yml`), not in `ci.yml`.

Worth noting that the drift checker did its job here — it flagged JetBrains before the link check did, and the flag turned out to mean "this donor stopped publishing the thing we depend on", not "there are some new rules to fold in".