### PR TITLE
Fix/agents framework neutrality

### DIFF
--- a/skills/go-ultimate/references/agents.md
+++ b/skills/go-ultimate/references/agents.md
@@ -14,9 +14,17 @@ This reference wins over generic agent-framework guidance for agent-loop
 structure, multi-agent topology, typed data flow between nodes, and the
 state-externalism rule below.
 
-> This reference is **framework-agnostic by intent**. Eino is cited as the
-> source of principles, not endorsed as the recommended framework. Apply the
-> rules in whatever framework (or hand-written code) you use.
+> **Framework-agnostic by intent — and here is how to read it.** Every rule
+> below is a principle that applies in any framework and in hand-written code.
+> Where a principle is clearer with a concrete API, the example comes from
+> [Eino](https://github.com/cloudwego/eino) (the donor these principles were
+> distilled from) and is fenced off under an **`Eino spelling`** label or an
+> inline `eino:` marker.
+>
+> **Anything so marked is an illustration, not a requirement.** No identifier
+> from it needs to exist in your stack; if your framework spells the same idea
+> differently, that is fine. Eino is cited as the source of the principles, not
+> endorsed as the recommended framework.
 
 ## Contents
 
@@ -25,7 +33,7 @@ state-externalism rule below.
 - [State-externalism](#state-externalism)
 - [The agent loop — ReAct](#the-agent-loop-react)
 - [Multi-agent topology — decision tree](#multi-agent-topology-decision-tree)
-- [Unified Agent interface shape](#unified-agent-interface-shape)
+- [Agent interface — what is actually required](#agent-interface-what-is-actually-required)
 - [Delegation primitives](#delegation-primitives)
 - [Interrupt / Resume](#interrupt-resume)
 - [Components implement only the paradigms real to them](#components-implement-only-the-paradigms-real-to-them)
@@ -48,19 +56,25 @@ deliberately rejects:
 The rules:
 
 - **Each node's input/output types stay as the developer expects.** Enforce
-  upstream/downstream type alignment at **compile time** (when the graph/chain
-  is built), not at runtime.
-- **Generics at boundaries** — `Graph[I, O]`, `Chain[I, O]`,
-  `StreamReader[T]`. Type mismatches surface at `Compile()` / `AddXXXNode()`,
-  not in production.
-- **`map[string]any` only at convergence boundaries**, produced by the
-  framework (e.g. `WithOutputKey("k")` wraps a node's output into a map entry),
-  never natively emitted by nodes. Symmetrically, `WithInputKey("k")` extracts
-  one field rather than forcing downstream nodes to accept maps.
+  upstream/downstream type alignment at **compile time** (when the graph or
+  chain is assembled), not at runtime.
+- **The composition primitives are generic in their input and output types**, so
+  a mismatch between two wired nodes is a build-time error rather than a
+  production panic.
+- **`map[string]any` only at convergence boundaries, and only produced by the
+  framework** — where a node genuinely must merge several upstreams, the
+  framework wraps a value under a key at that boundary and extracts it on the
+  other side. Nodes never natively emit or accept maps.
 - **Valid type-alignment relations** are a closed set: (1) same type;
   (2) downstream interface + upstream implements it (incl. `any` as trivial
   case); (3) upstream interface + downstream concrete type (only checkable at
   runtime).
+
+> **Eino spelling.** The generic primitives are `Graph[I, O]`, `Chain[I, O]` and
+> `StreamReader[T]`; mismatches surface at `Compile()` / `AddXXXNode()`. The
+> convergence helpers are `WithOutputKey("k")` (wraps a node's output into a map
+> entry) and `WithInputKey("k")` (extracts one field, rather than forcing
+> downstream nodes to accept maps).
 
 > This rule is the reason cross-agent state is typed via a generic `S` (see
 > State-externalism), never `map[string]any`.
@@ -72,32 +86,48 @@ The rules:
 **Nodes, branches, and handlers must not mutate their Input.**
 
 Inputs are passed by assignment, not copy — mutating a reference-type Input
-causes side effects and **concurrency hazards** (multiple SuperSteps may touch
-the same value). If modification is needed, **copy first**. The rule applies
-equally to `StreamReader` chunks.
+causes side effects and **concurrency hazards**, because agent runtimes execute
+nodes concurrently: several nodes running in the same execution round can hold a
+reference to the same Input value. If modification is needed, **copy first**.
+The rule applies equally to chunks of a streamed input.
 
-This is stronger than the usual "don't mutate args" because agents routinely
-execute nodes concurrently across SuperSteps.
+This is stronger than the usual "don't mutate args": in ordinary code the
+aliasing is usually visible in the call graph, whereas here the runtime decides
+what runs together, so the sharing is invisible at the call site.
+
+> **Eino spelling.** Eino calls one round of concurrent node execution a
+> **SuperStep** — the term comes from Pregel, the graph-execution model its
+> engine follows. Streamed chunks arrive as `StreamReader[T]`.
 
 ---
 
 ## State-externalism
 
-**Keep nodes state-agnostic.** State flows through external handlers, not
-baked into nodes.
+**Keep nodes state-agnostic.** State lives outside the node and reaches it
+through typed handlers, rather than being baked into the node.
 
-- **Global state via typed Pre/Post handlers** (`StatePreHandler[S]` /
-  `StatePostHandler[S]`, plus stream variants). They sit outside the node and
-  affect it only by replacing Input/Output.
-- **Cross-agent state is typed via a generic `S`** — never `map[string]any`.
-  This resolves the internal Eino tension (Doc 2's Shared Session *is*
-  `map[string]any`; we side with Doc 1's typed-state thesis).
+- **Global state via typed pre/post handlers.** A handler runs before or after
+  the node, sits outside it, and affects it only by replacing Input or Output —
+  so the node itself never reads or writes shared state directly. Streaming
+  variants exist for streamed inputs and outputs.
+- **Cross-agent state is a typed value, not `map[string]any`.** Parameterize it
+  (a generic `S`) so the compiler checks every access.
 - **`map[string]any` is permitted only as a KV-boundary escape hatch** for
   genuinely dynamic data (e.g. a free-form metadata bag), never as the
   universal agent-state contract.
-- **In-node state access** via the explicit `ProcessState[S any](ctx, handler
-  func(ctx, S) error) error` escape hatch when a node genuinely needs it. The
-  framework locks at all read/write positions.
+- **In-node state access needs an explicit, locked escape hatch.** When a node
+  genuinely must touch shared state, it goes through a function that takes a
+  callback and holds a lock across the read/write, rather than reaching for the
+  state directly.
+
+> **Eino spelling.** The handlers are `StatePreHandler[S]` /
+> `StatePostHandler[S]` plus stream variants; the escape hatch is
+> `ProcessState[S any](ctx, handler func(ctx, S) error) error`, and the framework
+> locks at all read/write positions.
+>
+> The typed-state rule also resolves a tension *inside* the Eino docs: the ADK
+> document's Shared Session **is** a `map[string]any`, while the orchestration
+> document argues for typed state. This skill sides with typed state.
 
 ---
 
@@ -110,55 +140,81 @@ baked into nodes.
 3. **Observe** — return the tool result to the LLM as an observation.
 4. Repeat until the LLM emits no tool call (final answer).
 
-**Cap iterations.** `MaxIterations` is mandatory — an unbounded ReAct loop is a
-bug. `MaxIterations = 0` may mean "unbounded" in some frameworks; treat that
-as a smell and set an explicit bound.
+**Cap iterations.** An explicit maximum-iteration bound is mandatory — an
+unbounded ReAct loop is a bug, not a configuration choice: a model that keeps
+emitting tool calls will burn budget until something else stops it. Set the
+bound yourself rather than inheriting a default, and check what your
+framework's zero value means: in several of them `0` is "unbounded", so
+leaving the field unset is the one setting you must never ship.
 
 ---
 
 ## Multi-agent topology — decision tree
 
-Six named archetypes (Eino ADK). Pick by the collaboration shape, not by
-fashion.
+Six named archetypes, taken from the Eino ADK taxonomy — the *shapes* are
+general and appear in every multi-agent framework, only the names and the
+API differ. Pick by the collaboration shape, not by fashion.
 
 | Topology | When to use | Key property |
 |---|---|---|
 | **Sequential** | Strict linear pipeline; each agent sees the full input + outputs of preceding agents. | Early-exit on any sub-agent emitting an exit/interrupt action. |
 | **Parallel** | Independent sub-tasks over the same input; order doesn't matter. | Sub-agents run in concurrent goroutines, share input, aggregate via `sync.WaitGroup`, output in **order received**. |
-| **Loop** | Refinement / accumulation; later iterations access prior history. | Bounded by `MaxIterations` or an `ExitAction`. |
+| **Loop** | Refinement / accumulation; later iterations access prior history. | Bounded by an iteration cap or an explicit exit signal from a sub-agent (eino: `ExitAction`). |
 | **Supervisor** | One router allocates tasks and aggregates; sub-agents are independently developable/testable/replaceable. | Sub-agents return control automatically on completion ("deterministic callback"). |
 | **Plan-Execute** | Closed-loop "think → act → adjust": Planner (structured plan) → Executor (first step) → Replanner (continue/replan/end). | Three roles; replanning is explicit. |
-| **DeepAgents** | Decompose a large goal into tracked todos, delegate subtasks via one unified `TaskTool`, isolate sub-agent contexts, main agent aggregates. | Tradeoff: over-decomposition increases call counts and cost. |
+| **DeepAgents** | Decompose a large goal into tracked todos, delegate subtasks through a single unified delegation tool (eino: `TaskTool`), isolate sub-agent contexts, main agent aggregates. | Tradeoff: over-decomposition increases call counts and cost. |
 
 ---
 
-## Unified Agent interface shape
+## Agent interface — what is actually required
 
-Every agent implements:
+Two properties are required of any agent that another agent can invoke. The
+**signature is your framework's business**; these two are not.
 
-```go
-type Agent interface {
-    Name(ctx context.Context) string
-    Description(ctx context.Context) string
-    Run(ctx context.Context, input *AgentInput, options ...AgentRunOption) *AsyncIterator[*AgentEvent]
-}
-```
+**1. Identity for discovery.** An agent exposes a name and a description that
+are readable at runtime, so a router or supervisor can select it without
+hard-coded knowledge. A description written for a human reader and never read by
+the router is not identity — see [Delegation primitives](#delegation-primitives).
 
-- `Name` and `Description` give the agent a clear identity for discovery and
-  invocation by other agents.
-- `Run` returns an **`*AsyncIterator[*AgentEvent]`**, not a blocking value.
-  Events carry node outputs (replies, tool results), state-modification
-  actions, and the running trajectory.
+**2. Event-driven, non-blocking return.** The run entrypoint yields a *stream of
+events* — node outputs (replies, tool results), state-modification actions, and
+the running trajectory — rather than blocking until a single final value.
 
-**Event-driven return is mandatory.** Blocking calls hide the trajectory and
-block streaming UX. Flow control (interrupt, jump, exit) is handled
-automatically by the runner framework.
+**Event-driven return is mandatory**, and for two concrete reasons rather than
+as an aesthetic preference:
+
+- **A blocking call hides the trajectory.** Everything the agent did on the way
+  to its answer is unobservable, which makes debugging and cost attribution
+  guesswork.
+- **A blocking call forecloses streaming UX.** You cannot show partial output
+  you never received.
+
+Flow control (interrupt, jump, exit) then belongs to the runner that consumes
+the event stream — not to the agent, and not to the caller.
+
+> **Eino spelling.** Eino ADK's `Agent` interface is one realization of the two
+> properties above:
+>
+> ```go
+> type Agent interface {
+>     Name(ctx context.Context) string
+>     Description(ctx context.Context) string
+>     Run(ctx context.Context, input *AgentInput, options ...AgentRunOption) *AsyncIterator[*AgentEvent]
+> }
+> ```
+>
+> `AgentInput`, `AgentRunOption` and `AsyncIterator[*AgentEvent]` are Eino types.
+> **Do not implement this interface in a project that does not use Eino** — an
+> `iter.Seq2`, a channel of events, or a callback all satisfy the requirement
+> equally well.
 
 ---
 
 ## Delegation primitives
 
-Two ways one agent invokes another — pick by what the callee needs:
+Two ways one agent invokes another — pick by what the callee needs. (The names
+are Eino ADK's; the distinction exists in every multi-agent framework, sometimes
+unnamed.)
 
 - **Transfer (parent → child)** — carries the full running context. Use when
   the callee needs the conversation/state so far.
@@ -166,7 +222,10 @@ Two ways one agent invokes another — pick by what the callee needs:
   context), like any other tool. Use when only the arguments matter.
 
 Choosing wrong (e.g. Agent-as-Tool when the callee actually needs history) is a
-common bug — the callee silently lacks context it expected.
+common bug — the callee silently lacks context it expected. The failure is quiet
+by construction: the callee still returns *an* answer, just one computed without
+the history it was designed around, so nothing errors and the quality drop looks
+like a model problem.
 
 ---
 
@@ -175,28 +234,46 @@ common bug — the callee silently lacks context it expected.
 Long-running, pausable, or human-in-the-loop scenarios use **Interrupt +
 Resume**, with persistence decoupled from resume logic:
 
-1. The agent emits an `Event` containing an **Interrupt action** (carrying a
-   state snapshot).
-2. The runner persists state via a registered **`CheckPointStore`** interface
-   (you implement the storage medium — DB, file, Redis).
-3. Later, `runner.Resume(ctx, checkpointID, newInput)` restarts from the
-   breakpoint with the new input.
+1. The agent emits an event carrying an **interrupt** with a state snapshot.
+2. The runner hands that snapshot to a **pluggable store** — an interface you
+   implement over whatever medium fits (DB, file, Redis).
+3. Later, a **resume entrypoint** restarts from the snapshot, identified by a
+   checkpoint id, with new input.
 
-**Implement `CheckPointStore` as a small, single-purpose interface.** Do not
-bake serialization/storage into the agent itself.
+**Keep persistence behind a small, single-purpose interface.** Do not bake
+serialization or storage into the agent itself: the agent should not know
+whether its checkpoint went to Postgres or to a temp file, and a checkpoint
+store that grows agent-specific methods has stopped being a store.
+
+> **Eino spelling.** The store interface is `CheckPointStore`; the resume
+> entrypoint is `runner.Resume(ctx, checkpointID, newInput)`; the interrupt
+> travels as an Interrupt action inside an `Event`.
 
 ---
 
 ## Components implement only the paradigms real to them
 
-A `ChatModel` does not need to implement `Collect`. Components implement only
-the streaming paradigms (Invoke / Stream / Collect / Transform) that are real
-in their business scenario; the orchestrator auto-fills the missing ones (Auto
-Concatenate / Box / Merge / Copy).
+This is the most framework-shaped section in this reference; the transferable
+part is the rule, not the taxonomy.
 
-For custom chunk types not in the built-in set (Message, string, `[]*Message`,
-Map, slices), register a concat func via the framework's equivalent of
-`RegisterStreamChunkConcatFunc`.
+A component should implement only the streaming paradigms that are **real in its
+business scenario**, and the orchestrator should adapt between paradigms for the
+rest. A chat model that has no meaningful "collect a stream into one value"
+behavior should not be forced to write one — an implementation that exists only
+to satisfy an interface is a stub that will be wrong the first time someone
+relies on it.
+
+The four paradigms are a useful general vocabulary, whatever your framework
+calls them: **invoke** (value in, value out), **stream** (value in, stream out),
+**collect** (stream in, value out), **transform** (stream in, stream out). If a
+framework can derive the missing three from the one you implemented — by
+concatenating a stream, wrapping a value, merging, or copying — let it.
+
+> **Eino spelling.** The paradigms are `Invoke` / `Stream` / `Collect` /
+> `Transform`; the automatic derivations are Auto Concatenate / Box / Merge /
+> Copy. For custom chunk types outside the built-in set (Message, string,
+> `[]*Message`, Map, slices), register a concat func with
+> `RegisterStreamChunkConcatFunc`.
 
 ---
 
@@ -219,16 +296,21 @@ Agent code is concurrent code. Apply [engineering-policy.md](engineering-policy.
 
 - **`map[string]any` between nodes** — the central anti-pattern this reference
   exists to prevent. Use typed generics.
-- **Mutating shared Input** across nodes / SuperSteps — concurrency hazards.
-- **Unbounded ReAct loops** — set an explicit `MaxIterations`.
+- **Mutating a shared Input** from concurrently executing nodes — concurrency
+  hazards.
+- **Unbounded ReAct loops** — set an explicit iteration cap, and never ship the
+  framework's zero value without checking whether it means "unbounded".
 - **Fire-and-forget goroutines** in agent loops — every goroutine needs an exit
   condition.
 - **Agent-as-Tool when the callee needs full context** — silently produces
   broken delegation.
-- **Baking serialization/storage into the agent** — use a separate
-  `CheckPointStore`.
+- **Baking serialization/storage into the agent** — put it behind a small,
+  pluggable checkpoint-store interface.
 - **Forcing every component to implement every streaming paradigm** — let the
-  orchestrator auto-fill.
+  orchestrator adapt between them.
+- **Implementing a donor framework's interface verbatim in a project that does
+  not use that framework** — everything marked `Eino spelling` above is an
+  illustration of a principle, not an API to copy.
 
 ---
 
@@ -245,3 +327,10 @@ Agent code is concurrent code. Apply [engineering-policy.md](engineering-policy.
 - [Phil Schmid — MCP best practices](https://www.philschmid.de/mcp-best-practices)
   (via [mcp-server.md](mcp-server.md)) — tool-design discipline that applies
   equally to agent tool-calling.
+
+**On the `Eino spelling` blocks.** Eino supplies this reference's worked examples
+because it is the donor the principles were distilled from, not because it is
+recommended. Each block is quarantined so a reader on Google ADK, LangChainGo or
+hand-written code can skip it without losing a rule: every mandatory statement in
+this file is outside those blocks. If you add material here from another
+framework, keep the same split — principle in the body, API in a marked block.

--- a/skills/go-ultimate/scripts/source-versions.json
+++ b/skills/go-ultimate/scripts/source-versions.json
@@ -38,10 +38,10 @@
     "eino": {
       "kind": "github-tag",
       "repo": "cloudwego/eino",
-      "_note": "Design docs live off-repo on cloudwego.io. Pinned to the tag commit; ADK/orchestration pattern drift detected via tag/release changes. 'adk-0.1' is an in-repo package, not a recoverable tag. Reviewed v0.9.13..v0.9.15 on 2026-08-19: the delta is three ADK-level changes (nil-ctx fix in the summarization middleware #1157, PatchedToolResultGenerator #1168, out-of-range read-offset reporting #1191). references/agents.md teaches orchestration principles — type-aligned composition, read-only input, state-externalism, ReAct, topology archetypes — not eino's API surface, so nothing needed folding in. Pin refreshed to clear the signal.",
-      "tag": "v0.9.15",
-      "commit_sha": "ebd616c8291e",
-      "reviewed_through": "v0.9.15",
+      "_note": "Design docs live off-repo on cloudwego.io. Pinned to the tag commit; ADK/orchestration pattern drift detected via tag/release changes. 'adk-0.1' is an in-repo package, not a recoverable tag. Reviewed v0.9.13..v0.9.15 on 2026-08-19: the delta is three ADK-level changes (nil-ctx fix in the summarization middleware #1157, PatchedToolResultGenerator #1168, out-of-range read-offset reporting #1191). references/agents.md teaches orchestration principles — type-aligned composition, read-only input, state-externalism, ReAct, topology archetypes — not eino's API surface, so nothing needed folding in. Pin refreshed to clear the signal. Reviewed v0.9.15..v0.9.17 on 2026-08-28: two internal compose-package bugfixes for nested-stream and boundary checkpoint converters (#1225, #1226). agents.md teaches the Interrupt/Resume principle (a small pluggable store, decoupled from the agent), not eino's checkpoint stream internals, so again nothing to fold in.",
+      "tag": "v0.9.17",
+      "commit_sha": "0e01b2a4e305",
+      "reviewed_through": "v0.9.17",
       "doc_ref": "references/agents.md"
     },
     "go-sdk": {


### PR DESCRIPTION
Closes #30

`references/agents.md` is the mandatory reference for the `AI AGENT` branch, and `SKILL.md` routes any Go agent task to it — but it presented cloudwego/eino's API surface as if it were universal. A reader on Google ADK, LangChainGo or hand-written code was told to implement types that exist in exactly one framework.

The file already claimed to be "framework-agnostic by intent", which made the gap worse rather than better: it asserted neutrality and then spent the body violating it.

Introduces one checkable convention and applies it throughout: principles live in the body, every eino identifier lives in a marked `Eino spelling` block or carries an inline `eino:` marker. Nothing marked that way is a requirement.

Per section:
- Type-aligned composition: the rule is now "composition primitives are generic in their I/O types, so a mismatch is a build-time error"; `Graph[I,O]`, `Chain[I,O]`, `StreamReader[T]`, `Compile()`, `AddXXXNode()`, `WithOutputKey` and `WithInputKey` moved into a marked block.
- Read-only input: "SuperSteps" was used as a plain noun with no definition. The hazard is now stated generally (agent runtimes execute nodes concurrently; nodes in the same round can alias one Input), with a note on why this is stronger than "don't mutate args" — the runtime decides what runs together, so the aliasing is invisible at the call site. SuperStep is defined in the marked block, with its Pregel provenance.
- State-externalism: leads with the principle (state lives outside the node and reaches it through typed handlers that can only replace `Input/Output`); `StatePreHandler[S]`, `StatePostHandler[S]` and `ProcessState` moved into the block, along with the note about the tension between the two eino documents.
- ReAct: MaxIterations replaced by "an explicit iteration cap", keeping the useful warning that a framework's zero value often means unbounded.
- Agent interface: renamed from "Unified Agent interface shape" — the old title and its "Every agent implements:" were the strongest overreach in the file. What is required is identity for discovery and event-driven non-blocking return, each now justified concretely. Eino ADK's interface is shown as one realization, with an explicit "do not implement this outside eino" and three neutral alternatives (`iter.Seq2`, a channel, a callback).
- Interrupt/Resume: principle is a small pluggable store decoupled from the agent; `CheckPointStore` and `runner.Resume` moved into the block.
- Streaming paradigms: flagged as the most framework-shaped section, with the four paradigms given as general vocabulary and eino's names/derivations and `RegisterStreamChunkConcatFunc` in the block.
- What to avoid: adds implementing a donor framework's interface verbatim in a project that does not use it.
- Sources: documents the convention so future additions keep the split.

Verified against the issue's acceptance criteria: every eino identifier in the file now sits inside a marked block or carries an inline marker; every mandatory statement outside those blocks is framework-neutral; SuperStep is defined at its only remaining use; the ~70%/~40% transferability estimates in Sources still hold. Contents and all in-file anchors updated and checked.

Opinions are unchanged: type-aligned composition, bounded iterations and event-driven return remain mandatory. This separates them from one vendor's spelling, it does not soften them.