### PR TITLE
Update skill for Go 1.27

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin.json",
   "name": "go-ultimate",
   "description": "Opinionated Go development skill — architecture, conventions, production readiness, repo/CI hygiene, review, and MCP/agent patterns.",
-  "version": "0.11.0",
+  "version": "0.12.0",
   "author": { "name": "Djarvur" },
   "homepage": "https://github.com/Djarvur/go-ultimate",
   "repository": "https://github.com/Djarvur/go-ultimate",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/codex-plugin.json",
   "name": "go-ultimate",
-  "version": "0.11.0",
+  "version": "0.12.0",
   "description": "Opinionated Go development skill — architecture, conventions, review, and MCP/agent patterns.",
   "author": {
     "name": "Djarvur",

--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/cursor-plugin.json",
   "name": "go-ultimate",
   "displayName": "Go Ultimate",
-  "version": "0.11.0",
+  "version": "0.12.0",
   "description": "Opinionated Go development skill — architecture, conventions, review, and MCP/agent patterns.",
   "author": {
     "name": "Djarvur",

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,11 +62,14 @@ jobs:
           git diff --exit-code -- $files
       - uses: golangci/golangci-lint-action@ba0d7d2ec06a0ea1cb5fa41b2e4a3ab91d21278a # v9.3.0
         with:
-          # Pin to v2: v1.x is built with Go < 1.26 and cannot lint go 1.26
-          # modules ("language version used to build golangci-lint is lower
-          # than the targeted Go version"). v2.9.0+ is built with Go 1.26.
+          # The linter must be built with a Go version >= the module's `go`
+          # directive, or it refuses to run ("language version used to build
+          # golangci-lint is lower than the targeted Go version"). The app
+          # templates target go 1.27, and go1.27 support landed in v2.13.0
+          # (#6642) — v2.12 cannot lint them. Bump this whenever the templates
+          # move to a new Go release.
           # Requires golangci-lint-action v7+ (v6 rejects v2 version strings).
-          version: v2.12
+          version: v2.13
           working-directory: skills/go-ultimate/assets/${{ matrix.template }}
 
   # Repo-wide: gofmt clean across all .go files.

--- a/.grok-plugin/plugin.json
+++ b/.grok-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/grok-plugin.json",
   "name": "go-ultimate",
   "displayName": "Go Ultimate",
-  "version": "0.11.0",
+  "version": "0.12.0",
   "description": "Opinionated Go development skill — architecture, conventions, review, and MCP/agent patterns.",
   "author": {
     "name": "Djarvur",

--- a/.plugin/plugin.json
+++ b/.plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "go-ultimate",
   "displayName": "Go Ultimate",
-  "version": "0.11.0",
+  "version": "0.12.0",
   "description": "Opinionated Go development skill — architecture, conventions, review, and MCP/agent patterns.",
   "author": {
     "name": "Djarvur",

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 A single, opinionated AI agent skill for writing the best Go programs — synthesized from four general-Go skills, four agent/MCP donors (one donor contributes two documents), the Google and Uber style guides, and a repository/production-practice donor. Routes any Go task (CLI, library, backend service, MCP server, AI agent) to the right architecture, conventions, and review checklist. Highly opinionated; overrides generic Go style and lint guidance on conflicts.
 
-> **Status:** v0.11.0. Designed for Claude Code, Codex, Cursor, Grok Build, GitHub Copilot CLI, OpenCode, and any harness that reads the Agent Skills `SKILL.md` format. MIT licensed.
+> **Status:** v0.12.0. Designed for Claude Code, Codex, Cursor, Grok Build, GitHub Copilot CLI, OpenCode, and any harness that reads the Agent Skills `SKILL.md` format. MIT licensed.
 
 ## What's inside
 
@@ -106,7 +106,7 @@ The skill synthesizes thirteen upstream sources. Full attribution and the live p
 
 **Repository / production practice:** `metalagman/agent-skills#go-senior-developer`, `#go-oss-maintainer`, `#golangci-lint-strict`.
 
-**Agent / MCP:** `cloudwego/eino#orchestration-design-principles`, `cloudwego/eino#adk-0.1`, `modelcontextprotocol/go-sdk` (v1.6.1), `philschmid.de#mcp-best-practices`, `modelcontextprotocol.info#docs/best-practices`.
+**Agent / MCP:** `cloudwego/eino#orchestration-design-principles`, `cloudwego/eino#adk-0.1`, `modelcontextprotocol/go-sdk` (v1.7.0), `philschmid.de#mcp-best-practices`, `modelcontextprotocol.info#docs/best-practices`.
 
 > Originally also sourced from `danicat/skills#go-best-practices` and `danicat/skills#go-project-setup`; both were deleted upstream on 2026-07-21. Their distilled content is now owned and maintained by this skill (project-setup boilerplates under `assets/`, best-practices material folded into `references/engineering-policy.md` and `references/code-review.md`).
 

--- a/skills/go-ultimate/SKILL.md
+++ b/skills/go-ultimate/SKILL.md
@@ -13,7 +13,7 @@ license: MIT
 compatibility: Designed for Claude Code, Codex, Cursor, Grok Build, GitHub Copilot CLI, OpenCode, and any harness that reads the Agent Skills SKILL.md format. Targets any Go project.
 metadata:
   author: Djarvur
-  version: '0.11.0'
+  version: '0.12.0'
   maintainers:
     - name: Daniel Podolsky
       url: https://github.com/onokonem
@@ -41,16 +41,20 @@ metadata:
       2026-07-21 (commit 201fa420, "skill optimisation and repo cleanup"). Their
       distilled content is now owned and maintained by go-ultimate — the
       project-setup boilerplates live under assets/ (verified to build with
-      Go 1.26.x) and the best-practices material is folded into
+      Go 1.27.x) and the best-practices material is folded into
       references/engineering-policy.md and references/code-review.md.
     jetbrains-restructured: |
       JetBrains/go-modern-guidelines restructured on 2026-08-11: the skill moved
       path and was rewritten from a static per-version markdown catalog into a
-      thin wrapper around a Modern Go Guidelines CLI. The catalog no longer
-      exists upstream as readable markdown, so references/modern-go.md now owns
-      it (same as the danicat material) and new Go releases are folded in by
-      hand. The CLI approach is deliberately not adopted — it would add a runtime
-      dependency on a third-party binary to an otherwise self-contained skill.
+      thin wrapper around a Modern Go Guidelines CLI. The catalog did not
+      disappear, it changed format — it is now structured data at
+      internal/guidelines/guidelines.json (Apache-2.0), so it stays diffable but
+      is no longer readable as prose. references/modern-go.md owns its own
+      catalog and is checked against that file by since_version when a new Go
+      release lands; entries are adopted only after verifying them against a
+      real toolchain. The CLI approach is deliberately not adopted — it would
+      add a runtime dependency on a third-party binary to an otherwise
+      self-contained skill.
     cloudwego-eino-adk-0.1: |
       `adk-0.1` is an in-repo ADK package, not a versioned tag; treated as a
       point-in-time reference, not a recoverable pin.

--- a/skills/go-ultimate/assets/ci/lint.yml
+++ b/skills/go-ultimate/assets/ci/lint.yml
@@ -34,7 +34,9 @@ jobs:
       # than the targeted Go version").
       - uses: golangci/golangci-lint-action@v7
         with:
-          version: v2.12
+          # go1.27 support landed in golangci-lint v2.13.0; a module with a
+          # newer `go` directive than the linter's own build needs a newer pin.
+          version: v2.13
 
       # gofmt is not part of the golangci-lint v2 default set; assert it here so
       # formatting never reaches review.

--- a/skills/go-ultimate/assets/cli-cobra/go.mod
+++ b/skills/go-ultimate/assets/cli-cobra/go.mod
@@ -1,6 +1,6 @@
 module example.com/my-cli
 
-go 1.26
+go 1.27
 
 require github.com/spf13/cobra v1.10.2
 

--- a/skills/go-ultimate/assets/cli-simple/go.mod
+++ b/skills/go-ultimate/assets/cli-simple/go.mod
@@ -1,3 +1,3 @@
 module example.com/my-tool
 
-go 1.26
+go 1.27

--- a/skills/go-ultimate/assets/game/go.mod
+++ b/skills/go-ultimate/assets/game/go.mod
@@ -1,6 +1,6 @@
 module example.com/game
 
-go 1.26
+go 1.27
 
 require github.com/hajimehoshi/ebiten/v2 v2.9.10
 

--- a/skills/go-ultimate/assets/library/go.mod
+++ b/skills/go-ultimate/assets/library/go.mod
@@ -1,3 +1,3 @@
 module example.com/library
 
-go 1.25
+go 1.26

--- a/skills/go-ultimate/assets/mcp-server/go.mod
+++ b/skills/go-ultimate/assets/mcp-server/go.mod
@@ -1,6 +1,6 @@
 module example.com/mcp-server
 
-go 1.26
+go 1.27
 
 require github.com/modelcontextprotocol/go-sdk v1.7.0
 

--- a/skills/go-ultimate/assets/webservice/go.mod
+++ b/skills/go-ultimate/assets/webservice/go.mod
@@ -1,3 +1,3 @@
 module example.com/webservice
 
-go 1.26
+go 1.27

--- a/skills/go-ultimate/references/modern-go.md
+++ b/skills/go-ultimate/references/modern-go.md
@@ -183,6 +183,41 @@ if pathErr, ok := errors.AsType[*os.PathError](err); ok {
 }
 ```
 
+### Go 1.27+
+
+- **Generic methods.** Type parameters are allowed on methods, so an operation
+  that belongs to a type can live on it instead of becoming a package-level
+  helper. Keep package-level generics for operations that do not belong to one
+  receiver.
+- **`encoding/json/v2`** for *new* JSON code. Leave existing `encoding/json`
+  code alone unless migration is explicitly requested — this is an additive
+  choice for new code, not a rewrite mandate.
+- **Promoted fields in composite literals.** Set an embedded struct's fields
+  directly by their promoted names instead of constructing the embedded value.
+- **`strings.CutLast` / `bytes.CutLast`** instead of `LastIndex` plus manual
+  slicing around the last separator.
+- **Standard-library `uuid`** (RFC 9562) instead of a third-party package or a
+  hand-rolled implementation. Its random component uses a CSPRNG.
+- **`url.URL.Clone` / `url.Values.Clone`** instead of copying by hand.
+
+```go
+// 1.27+
+type Set[T comparable] map[T]struct{}
+
+// Generic method: the operation belongs to the type.
+func (s Set[T]) MapTo[U any](f func(T) U) []U { ... }
+
+// Promoted field set directly; no Item{Base: Base{ID: 7}}.
+type Item struct {
+    Base
+    Name string
+}
+it := Item{ID: 7, Name: "x"}
+
+before, after, found := strings.CutLast("a/b/c", "/") // "a/b", "c", true
+u2 := u.Clone()
+```
+
 ---
 
 ## Source
@@ -195,19 +230,27 @@ which carried the full per-version catalog with before/after examples inline.
 [`plugin/skills/use-modern-go/SKILL.md`](https://github.com/JetBrains/go-modern-guidelines/blob/main/plugin/skills/use-modern-go/SKILL.md)
 and was rewritten from a static markdown catalog into a thin wrapper that shells
 out to a Modern Go Guidelines CLI (`list` / `explain` subcommands) which resolves
-guidelines at runtime. **The per-version catalog no longer exists upstream as
-readable markdown.**
+guidelines at runtime.
+
+**The catalog itself did not disappear — it changed format.** It now lives in
+that repository as structured data at
+[`internal/guidelines/guidelines.json`](https://github.com/JetBrains/go-modern-guidelines/blob/main/internal/guidelines/guidelines.json)
+(one record per guideline: `id`, `since_version`, `guideline`, `details`,
+`examples`), and the repository is Apache-2.0. So it remains **diffable**, just
+not readable as prose.
 
 Consequences for this skill:
 
-- **The catalog below is now owned and maintained here**, the same way the
-  danicat material is (see SKILL.md `source-notes`). New Go releases must be
-  folded in by hand rather than diffed against upstream.
+- **This catalog is maintained here, but checked against upstream.** When a new
+  Go release lands, diff `guidelines.json` by `since_version` against the
+  sections above rather than re-deriving the list from scratch. Entries are
+  adopted only after verifying them against a real toolchain — upstream is a
+  cross-check, not an authority.
 - go-ultimate deliberately does **not** adopt the CLI approach: it would add a
   runtime dependency on a third-party binary to a skill that is otherwise
   self-contained, and version detection is already covered by the bundled
-  [`scripts/goversion/main.go`](../scripts/goversion/main.go). Revisit only if
-  the catalog becomes too costly to maintain by hand.
+  [`scripts/goversion/main.go`](../scripts/goversion/main.go).
 - The upstream pin in
-  [`scripts/source-versions.json`](../scripts/source-versions.json) tracks the
-  new path, so a future change to the CLI-based skill is still detected.
+  [`scripts/source-versions.json`](../scripts/source-versions.json) tracks
+  `guidelines.json` rather than the wrapper `SKILL.md`, so drift fires when the
+  *guidelines* change and stays quiet on plugin version bumps.

--- a/skills/go-ultimate/references/repo-and-ci.md
+++ b/skills/go-ultimate/references/repo-and-ci.md
@@ -207,7 +207,7 @@ with, and own.
 ```
 
 `go-version-file` means the version lives in exactly one place. A hardcoded
-`go-version: '1.25'` in the workflow silently diverges from `go.mod` the first
+`go-version: '1.26'` in the workflow silently diverges from `go.mod` the first
 time someone bumps one and not the other, and then CI is testing a different
 language version than the code declares.
 
@@ -252,7 +252,7 @@ jobs:
           go-version-file: go.mod
       - uses: golangci/golangci-lint-action@v7
         with:
-          version: v2.12   # pinned on purpose
+          version: v2.13   # pinned on purpose
 
   vuln:
     runs-on: ubuntu-latest
@@ -288,7 +288,7 @@ it claims to support — at minimum the `go.mod` floor and the current release:
 ```yaml
 strategy:
   matrix:
-    go: ['1.25', '1.26']
+    go: ['1.26', '1.27']
 ```
 
 See [engineering-policy.md § `go.mod` version policy](engineering-policy.md) for
@@ -349,7 +349,7 @@ Use a **multi-stage build**. The final image contains the binary and its
 runtime dependencies, nothing else — no toolchain, no source, no module cache.
 
 ```dockerfile
-FROM golang:1.26 AS build
+FROM golang:1.27 AS build
 WORKDIR /src
 COPY go.mod go.sum ./
 RUN go mod download

--- a/skills/go-ultimate/scripts/source-versions.json
+++ b/skills/go-ultimate/scripts/source-versions.json
@@ -1,6 +1,6 @@
 {
   "_comment": "Baseline pins for go-ultimate's donor sources. Used by scripts/check-source-versions.sh to detect upstream drift. Update a pin whenever you fold a change from that donor back into the skill (and bump SKILL.md version). Pin types: commit_sha = last commit touching a GitHub path (kind: github-path); tag = latest stable release/tag (kind: github-tag); manual-review = not auto-checked, records last_reviewed date (kind: manual-review).",
-  "_updated": "2026-08-19",
+  "_updated": "2026-08-28",
   "sources": {
     "teetsh-review": {
       "kind": "github-path",
@@ -12,11 +12,14 @@
     "jetbrains-modern-go": {
       "kind": "github-path",
       "repo": "JetBrains/go-modern-guidelines",
-      "path": "plugin/skills/use-modern-go/SKILL.md",
-      "commit_sha": "7b56a40ab86f",
+      "path": "internal/guidelines/guidelines.json",
+      "commit_sha": "937827b86eef",
       "condensed_from_sha": "3a7f3eecd29f",
+      "license": "Apache-2.0",
       "old_path": "claude/modern-go-guidelines/skills/use-modern-go/SKILL.md",
-      "_note": "Upstream restructured on 2026-08-11: the skill moved from old_path to plugin/skills/use-modern-go/SKILL.md AND was rewritten from a static per-version markdown catalog into a thin wrapper around a Modern Go Guidelines CLI (list/explain subcommands, installed on first use). 198b4e1c8534 is the commit that removed the old path; 7b56a40ab86f is the current head of the new one. The catalog no longer exists upstream as readable markdown, so references/modern-go.md now owns that content (danicat precedent) and new Go releases are folded in by hand. condensed_from_sha records the last revision that still carried the catalog — it is also the permalink cited in references/modern-go.md, since linking the current file would point at material that no longer contains what was condensed. The pin tracks the new path so future changes to the CLI-based skill are still detected, but drift there is no longer a signal to re-condense.",
+      "previous_path": "plugin/skills/use-modern-go/SKILL.md",
+      "reviewed_through": "Go 1.27 guidelines (54 entries)",
+      "_note": "Upstream restructured on 2026-08-11: the skill moved from old_path to previous_path AND was rewritten from a static per-version markdown catalog into a thin wrapper around a Modern Go Guidelines CLI (list/explain). Correction to the earlier note here: the catalog did not disappear, it changed format — it lives at internal/guidelines/guidelines.json (54 records: id, since_version, guideline, details, examples) and the repo is Apache-2.0, so it stays diffable, just not readable as prose. The pin therefore tracks guidelines.json rather than the wrapper SKILL.md: drift now fires when the guidelines change and stays quiet on plugin version bumps (the 2026-08-19 bump to 1.1.1 was pure noise under the old pin). references/modern-go.md still owns its catalog and is checked against this file by since_version; entries are adopted only after verifying them against a real toolchain. Reviewed 2026-08-28: diffed all 54 entries, found six Go 1.27 guidelines absent from modern-go.md (generic methods, encoding/json/v2, promoted field literals, strings/bytes.CutLast, stdlib uuid, url Clone) — all six verified by compiling against go1.27.0 and folded in.",
       "doc_ref": "references/modern-go.md"
     },
     "powerman-bch": {


### PR DESCRIPTION
Started as "look at the jetbrains-modern-go drift". The drift commit itself (40781f167719) is noise — a plugin version bump to 1.1.1 plus one line of skill description, +1/-1 across six files. Investigating it surfaced two real things.

1. The earlier note here was wrong in a way that mattered.

After the 2026-08-11 restructure this repo recorded that the per-version catalog "no longer exists upstream as readable markdown", concluded that `modern-go.md` now owns it outright, and pinned the CLI-wrapper `SKILL.md`. Half right: the catalog did not disappear, it changed format. It lives at `internal/guidelines/guidelines.json` — 54 records of `{id, since_version, guideline, details, examples}` — and the repo is Apache-2.0. It is still diffable, just not prose.

The pin now tracks `guidelines.json` instead of the wrapper, so drift fires when the guidelines change and stays quiet on plugin version bumps. Under the old pin the signal was exactly inverted: it fired on a version bump and would have stayed silent had the guidelines changed. The note in `source-versions.json`, `SKILL.md`'s source-note and `modern-go.md`'s § Source are corrected to match.

2. Go 1.27 is out and the catalog stopped at 1.26.

For a skill whose first principle is "use every feature up to the project's go.mod version", missing the newest release is a hole in the flagship mechanic. Six 1.27 guidelines were absent. All six were verified by compiling against a real go1.27.0 toolchain rather than trusted from the donor's JSON:

- generic methods (type parameters on methods)
- encoding/json/v2 for new JSON code, existing encoding/json left alone
- promoted embedded-struct fields in composite literals
- `strings.CutLast` / `bytes.CutLast`
- standard-library uuid (RFC 9562, CSPRNG-backed)
- `url.URL.Clone` / `url.Values.Clone`

Per the skill's own go.mod policy (applications: latest; libraries: latest-1) this also moves the templates: cli-simple, cli-cobra, game, mcp-server and webservice to go 1.27, library to go 1.26. All six pass build, vet, test -race and golangci-lint with zero issues on go1.27.0; only go.mod changed, no go.sum churn.

That bump breaks the linter pin. golangci-lint refuses to run when it is built with an older Go than the module's directive, and go1.27 support landed in v2.13.0 (#6642) — so v2.12 cannot lint these templates. Bumped to v2.13 in `.github/workflows/ci.yml` and in `assets/ci/lint.yml`, with the stale "v2.9.0+ is built with Go 1.26" comment replaced by the actual rule and a reminder to move it whenever the templates move.

`repo-and-ci.md` follows: library CI matrix 1.25/1.26 -> 1.26/1.27, Dockerfile base golang:1.26 -> golang:1.27, and the hardcoded-version example bumped so it stays one behind the templates rather than two.

Also fixes a stale fact in README's donor list: go-sdk is pinned at v1.7.0, not v1.6.1.

Skill version 0.12.0 across all seven locations. Drift checker reports no drift across every tracked source.